### PR TITLE
Remove bogus references to an HTML file as a CSS stylesheet

### DIFF
--- a/guide/reporting.html
+++ b/guide/reporting.html
@@ -5,9 +5,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
   <title>Submitting tests for the QT3 Test Suite</title>
-  <link
-  href="http://www.w3.org/XML/Group/xquery-test/TestSuiteStagingArXQTSCatalogExplain.html"
-  rel="stylesheet" type="text/css" />
 </head>
 
 <body xml:lang="en" lang="en">

--- a/guide/running.html
+++ b/guide/running.html
@@ -5,9 +5,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
   <title>Running the QT3 Test Suite</title>
-  <link
-  href="http://www.w3.org/XML/Group/xquery-test/TestSuiteStagingArXQTSCatalogExplain.html"
-  rel="stylesheet" type="text/css" />
 </head>
 
 <body xml:lang="en" lang="en">

--- a/guide/submitting.html
+++ b/guide/submitting.html
@@ -5,9 +5,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
   <title>Writing and Submitting tests for the QT3 Test Suite</title>
-  <link
-  href="http://www.w3.org/XML/Group/xquery-test/TestSuiteStagingArXQTSCatalogExplain.html"
-  rel="stylesheet" type="text/css" />
 </head>
 
 <body xml:lang="en" lang="en">


### PR DESCRIPTION
These guides claim to link to a CSS stylesheet:

```
  <link
  href="http://www.w3.org/XML/Group/xquery-test/TestSuiteStagingArXQTSCatalogExplain.html"
  rel="stylesheet" type="text/css" />
```

1. That file is inaccessible without W3C credentials.
2. I don't believe it's a CSS stylesheet

I removed it.