### PR TITLE
Keyword arguments replaced by conventional arguments

### DIFF
--- a/fn/expanded-QName.xml
+++ b/fn/expanded-QName.xml
@@ -27,9 +27,9 @@
    </test-case>
    
    <test-case name="expanded-QName-003">
-      <description> Test function fn:expanded-QName. Simple case. With keyword argument</description>
+      <description> Test function fn:expanded-QName. Simple case</description>
       <created by="Michael Kay" on="2022-10-13"/>
-      <test>expanded-QName(qname := QName("http://www.example.com/example", "person"))</test>
+      <test>expanded-QName(QName("http://www.example.com/example", "person"))</test>
       <result>
          <assert-eq>"Q{http://www.example.com/example}person"</assert-eq>
       </result>
@@ -39,7 +39,7 @@
       <description> Test function fn:expanded-QName. Angle brackets etc in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
       <dependency type="spec" value="XP40+"/>
-      <test><![CDATA[expanded-QName(qname := QName("http://www.example.com/example?code=<a>&status=<b>", "person"))]]></test>
+      <test><![CDATA[expanded-QName(QName("http://www.example.com/example?code=<a>&status=<b>", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?code=<a>&status=<b>}person"]]></assert-eq>
       </result>
@@ -49,7 +49,7 @@
       <description> Test function fn:expanded-QName. Angle brackets etc in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
       <dependency type="spec" value="XQ40+"/>
-      <test><![CDATA[expanded-QName(qname := QName("http://www.example.com/example?code=&lt;a>&amp;status=&lt;b>", "person"))]]></test>
+      <test><![CDATA[expanded-QName(QName("http://www.example.com/example?code=&lt;a>&amp;status=&lt;b>", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?code=<a>&status=<b>}person"]]></assert-eq>
       </result>
@@ -58,7 +58,7 @@
    <test-case name="expanded-QName-005">
       <description> Test function fn:expanded-QName. Braces in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
-      <test><![CDATA[expanded-QName(qname := QName("http://www.example.com/example?match=a{3}", "person"))]]></test>
+      <test><![CDATA[expanded-QName(QName("http://www.example.com/example?match=a{3}", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?match=a{3}}person"]]></assert-eq>
       </result>
@@ -67,7 +67,7 @@
    <test-case name="expanded-QName-006">
       <description> Test function fn:expanded-QName. Spaces in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
-      <test><![CDATA[expanded-QName(qname := QName("http://www.example.com/example?match=a b", "person"))]]></test>
+      <test><![CDATA[expanded-QName(QName("http://www.example.com/example?match=a b", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?match=a b}person"]]></assert-eq>
       </result>
@@ -76,7 +76,7 @@
    <test-case name="expanded-QName-007">
       <description> Test function fn:expanded-QName. Percent encoding in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
-      <test><![CDATA[expanded-QName(qname := QName("http://www.example.com/example?match=a%20b", "person"))]]></test>
+      <test><![CDATA[expanded-QName(QName("http://www.example.com/example?match=a%20b", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?match=a%20b}person"]]></assert-eq>
       </result>

--- a/fn/expanded-QName.xml
+++ b/fn/expanded-QName.xml
@@ -41,7 +41,7 @@
       <dependency type="spec" value="XP40+"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?code=<a>&status=<b>", "person"))]]></test>
       <result>
-         <assert-eq><![CDATA["Q{http://www.example.com/example?code=<a>&status=<b>}person"]]></assert-eq>
+         <assert-string-value><![CDATA[Q{http://www.example.com/example?code=<a>&status=<b>}person]]></assert-string-value>
       </result>
    </test-case>
    
@@ -51,7 +51,7 @@
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?code=&lt;a>&amp;status=&lt;b>", "person"))]]></test>
       <result>
-         <assert-eq><![CDATA["Q{http://www.example.com/example?code=<a>&status=<b>}person"]]></assert-eq>
+         <assert-string-value><![CDATA[Q{http://www.example.com/example?code=<a>&status=<b>}person]]></assert-string-value>
       </result>
    </test-case>
    

--- a/fn/expanded-QName.xml
+++ b/fn/expanded-QName.xml
@@ -29,6 +29,7 @@
    <test-case name="expanded-QName-003">
       <description> Test function fn:expanded-QName. Simple case</description>
       <created by="Michael Kay" on="2022-10-13"/>
+      <modified by="Christian Gruen" on="2022-11-15" change="keyword argument replaced by conventional argument"/>
       <test>expanded-QName(QName("http://www.example.com/example", "person"))</test>
       <result>
          <assert-eq>"Q{http://www.example.com/example}person"</assert-eq>
@@ -38,6 +39,7 @@
    <test-case name="expanded-QName-004-XP">
       <description> Test function fn:expanded-QName. Angle brackets etc in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
+      <modified by="Christian Gruen" on="2022-11-15" change="assertion changed to string comparison"/>
       <dependency type="spec" value="XP40+"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?code=<a>&status=<b>", "person"))]]></test>
       <result>
@@ -48,6 +50,7 @@
    <test-case name="expanded-QName-004-XQ">
       <description> Test function fn:expanded-QName. Angle brackets etc in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
+      <modified by="Christian Gruen" on="2022-11-15" change="assertion changed to string comparison"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?code=&lt;a>&amp;status=&lt;b>", "person"))]]></test>
       <result>
@@ -58,6 +61,7 @@
    <test-case name="expanded-QName-005">
       <description> Test function fn:expanded-QName. Braces in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
+      <modified by="Christian Gruen" on="2022-11-15" change="keyword argument replaced by conventional argument"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?match=a{3}", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?match=a{3}}person"]]></assert-eq>
@@ -67,6 +71,7 @@
    <test-case name="expanded-QName-006">
       <description> Test function fn:expanded-QName. Spaces in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
+      <modified by="Christian Gruen" on="2022-11-15" change="keyword argument replaced by conventional argument"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?match=a b", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?match=a b}person"]]></assert-eq>
@@ -76,6 +81,7 @@
    <test-case name="expanded-QName-007">
       <description> Test function fn:expanded-QName. Percent encoding in URI</description>
       <created by="Michael Kay" on="2022-10-13"/>
+      <modified by="Christian Gruen" on="2022-11-15" change="keyword argument replaced by conventional argument"/>
       <test><![CDATA[expanded-QName(QName("http://www.example.com/example?match=a%20b", "person"))]]></test>
       <result>
          <assert-eq><![CDATA["Q{http://www.example.com/example?match=a%20b}person"]]></assert-eq>

--- a/fn/parse-xml-fragment.xml
+++ b/fn/parse-xml-fragment.xml
@@ -131,10 +131,11 @@
         <description>parse-xml-fragment test - numeric character references are OK</description>
         <created by="Michael Kay, Saxonica" on="2012-07-05"/>
         <modified by="Michael Kay, Saxonica" on="2020-01-14" change="simplify testing of result assertion"/>
+        <modified by="Christian Gruen" on="2022-11-15" change="assertion changed to string comparison"/>
         <environment name="empty"/>
         <test>string(parse-xml-fragment(codepoints-to-string((38, 35, 51, 56, 59))))</test>
         <result>
-            <assert-eq>"&amp;"</assert-eq>
+            <assert-string-value>&amp;</assert-string-value>
         </result>
     </test-case>
     <test-case name="parse-xml-fragment-013">


### PR DESCRIPTION
@michaelhkay I believe we can get rid of the keyword argument syntax in these particular test cases.