### PR TITLE
fn:char: double-escape XML entities

### DIFF
--- a/fn/char.xml
+++ b/fn/char.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="fn-char">
-   <description>Tests for the remove() function</description>
+   <description>Tests for the fn:char function</description>
    <link type="spec" document="http://www.w3.org/TR/xpath-functions-30/"
       idref="func-char"/>
    
@@ -171,7 +171,7 @@
    <test-case name="fn-char-113">
       <description> hex literals </description>
       <created by="Michael Kay" on="2023-01-17"/>
-      <test>fn:char("&amp;#x1f600") => string-to-codepoints()</test>
+      <test>fn:char("&amp;amp;#x1f600") => string-to-codepoints()</test>
       <result>
          <error code="FOCH0005"/>
       </result>
@@ -297,7 +297,7 @@
    <test-case name="fn-char-213">
       <description> decimal literals </description>
       <created by="Michael Kay" on="2023-01-17"/>
-      <test>fn:char("&amp;#128512") => string-to-codepoints()</test>
+      <test>fn:char("&amp;amp;#128512") => string-to-codepoints()</test>
       <result>
          <error code="FOCH0005"/>
       </result>
@@ -468,7 +468,7 @@
    <test-case name="fn-char-907">
       <description> error cases </description>
       <created by="Michael Kay" on="2023-01-17"/>
-      <test>fn:char(("&amp;dollar")) => string-to-codepoints()</test>
+      <test>fn:char(("&amp;amp;dollar")) => string-to-codepoints()</test>
       <result>
          <error code="FOCH0005"/>
       </result>
@@ -477,7 +477,7 @@
    <test-case name="fn-char-908">
       <description> error cases </description>
       <created by="Michael Kay" on="2023-01-17"/>
-      <test>fn:char(("&amp;dollar;")) => string-to-codepoints()</test>
+      <test>fn:char(("&amp;amp;dollar;")) => string-to-codepoints()</test>
       <result>
          <error code="FOCH0005"/>
       </result>


### PR DESCRIPTION
Trivia: Entities need to be double-escaped. Otherwise, the resulting query string will be `fn:char("&#x1f600")` and similar.
