### PR TITLE
The fn:trunk tests require 4.0

### DIFF
--- a/fn/trunk.xml
+++ b/fn/trunk.xml
@@ -3,7 +3,7 @@
    <description>Tests for the trunk() function</description>
    <link type="spec" document="http://www.w3.org/TR/xpath-functions-30/"
          idref="func-head"/>
-   <dependency type="spec" value="XP30+ XQ30+"/>
+   <dependency type="spec" value="XP40+ XQ40+"/>
 
    <test-case name="trunk-001">
       <description> trunk() of a simple sequence </description>


### PR DESCRIPTION
Just updating the spec dependency to 40.