### PR TITLE
Resolve action QT4CG-042-01, use sequences instead of arrays in parse-uri/build-uri

### DIFF
--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -14,7 +14,7 @@
         "authority": "example.com",
         "host": "example.com",
         "path": "/path/to/file",
-        "path-segments": [ "", "path", "to", "file" ],
+        "path-segments": ("", "path", "to", "file"),
         "scheme": "https",
         "uri": "https://example.com\path\to\file"
       })</test>
@@ -29,7 +29,7 @@
                            'authority': 'user:password@example.com:443',
                            'host': 'example.com',
                            'port': '443',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'})</test>
     <result><assert-eq>"https://example.com:443/path"</assert-eq></result>
   </test-case>
@@ -53,7 +53,7 @@
                            'authority': 'user:password@example.com:443',
                            'port': '443',
                            'host': 'example.com',
-                           'path-segments': ['','path','a/b','a b'],
+                           'path-segments': ('','path','a/b','a b'),
                            'path': '/path/a%2fb/a+b'})</test>
     <result>
       <any-of>
@@ -71,7 +71,7 @@
         "fragment": "parse-uri",
         "host": "qt4cg.org",
         "path": "/specifications/xpath-functions-40/Overview.html",
-        "path-segments": [ "", "specifications", "xpath-functions-40", "Overview.html" ],
+        "path-segments": ("", "specifications", "xpath-functions-40", "Overview.html"),
         "scheme": "https",
         "uri": "https://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
       })</test>
@@ -87,7 +87,7 @@
   "authority": "www.ietf.org",
   "host": "www.ietf.org",
   "path": "/rfc/rfc2396.txt",
-  "path-segments": array { "", "rfc", "rfc2396.txt" }
+  "path-segments": ("", "rfc", "rfc2396.txt")
 })</test>
     <result><assert-eq>"http://www.ietf.org/rfc/rfc2396.txt"</assert-eq></result>
   </test-case>
@@ -101,7 +101,7 @@
   "authority": "example.com",
   "host": "example.com",
   "path": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 })</test>
     <result><assert-eq>"https://example.com/path/to/file"</assert-eq></result>
   </test-case>
@@ -120,16 +120,18 @@
   "port": "8080",
   "path": "/path",
   "query": "s=%22hello world%22" || $amp || ";sort=relevance",
-  "query-segments": array {
-    map { "key": "s", "value": """hello world""" },
-    map { "key": "sort", "value": "relevance" }
+  "query-parameters": map {
+    "s": """hello world""",
+    "sort": "relevance"
   },
-  "path-segments": array { "", "path" }
+  "path-segments": ("", "path")
 })</test>
     <result>
       <any-of>
-        <assert-eq>`https://example.com:8080/path?s="hello+world"&amp;sort=relevance`</assert-eq>
-        <assert-eq>`https://example.com:8080/path?s="hello%20world"&amp;sort=relevance`</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="hello+world"&amp;sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="hello%20world"&amp;sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="sort=relevance&amp;hello+world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="sort=relevance&amp;hello%20world"'</assert-eq>
       </any-of>
     </result>
   </test-case>
@@ -144,7 +146,7 @@
   "userinfo": "user",
   "host": "example.com",
   "path": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 })</test>
     <result><assert-eq>"https://user@example.com/path/to/file"</assert-eq></result>
   </test-case>
@@ -158,7 +160,7 @@
   "authority": "ftp.is.co.za",
   "host": "ftp.is.co.za",
   "path": "/rfc/rfc1808.txt",
-  "path-segments": array { "", "rfc", "rfc1808.txt" }
+  "path-segments": ("", "rfc", "rfc1808.txt")
 })</test>
     <result><assert-eq>"ftp://ftp.is.co.za/rfc/rfc1808.txt"</assert-eq></result>
   </test-case>
@@ -173,7 +175,7 @@
   "authority": "uncname",
   "host": "uncname",
   "path": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 })</test>
     <result><assert-eq>"file:////uncname/path/to/file"</assert-eq></result>
   </test-case>
@@ -186,7 +188,7 @@
   "uri": "file:///c:/path/to/file",
   "scheme": "file",
   "path": "/c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 })</test>
     <result>
       <any-of>
@@ -202,7 +204,7 @@
   "uri": "file:/C:/Program%20Files/test.jar",
   "scheme": "file",
   "path": "/C:/Program%20Files/test.jar",
-  "path-segments": array { "", "C:", "Program Files", "test.jar" }
+  "path-segments": ("", "C:", "Program Files", "test.jar")
 })</test>
     <result>
       <any-of>
@@ -219,7 +221,7 @@
   "uri": "file:\\c:\path\to\file",
   "scheme": "file",
   "path": "/c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 })</test>
     <result>
       <any-of>
@@ -235,7 +237,7 @@
   "uri": "file:\c:\path\to\file",
   "scheme": "file",
   "path": "/c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 })</test>
     <result>
       <any-of>
@@ -251,7 +253,7 @@
   "uri": "c:\path\to\file",
   "scheme": "file",
   "path": "/c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 })</test>
     <result>
       <any-of>
@@ -266,7 +268,7 @@
     <test>fn:build-uri(map {
   "uri": "/path/to/file",
   "path": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 })</test>
     <result><assert-eq>"/path/to/file"</assert-eq></result>
   </test-case>
@@ -287,8 +289,8 @@
     <test>fn:build-uri(map {
   "uri": "?q=1",
   "query": "q=1",
-  "query-segments": array {
-    map { "key": "q", "value": "1" }
+  "query-parameters": map {
+    "q": "1"
   }
 })</test>
     <result><assert-eq>"?q=1"</assert-eq></result>
@@ -304,10 +306,10 @@
   "host": "[2001:db8::7]",
   "path": "/c=GB",
   "query": "objectClass?one",
-  "query-segments": array {
-    map { "value": "objectClass?one" }
+  "query-parameters": map {
+    "": "objectClass?one"
   },
-  "path-segments": array { "", "c=GB" }
+  "path-segments": ("", "c=GB")
 })</test>
     <result>
       <any-of>
@@ -324,7 +326,7 @@
   "uri": "mailto:John.Doe@example.com",
   "scheme": "mailto",
   "path": "John.Doe@example.com",
-  "path-segments": array { "John.Doe@example.com" }
+  "path-segments": "John.Doe@example.com"
 })</test>
     <result>
       <assert-eq>"mailto:John.Doe@example.com"</assert-eq>
@@ -338,7 +340,7 @@
   "uri": "news:comp.infosystems.www.servers.unix",
   "scheme": "news",
   "path": "comp.infosystems.www.servers.unix",
-  "path-segments": array { "comp.infosystems.www.servers.unix" }
+  "path-segments": "comp.infosystems.www.servers.unix"
 })</test>
     <result><assert-eq>"news:comp.infosystems.www.servers.unix"</assert-eq></result>
   </test-case>
@@ -350,7 +352,7 @@
   "uri": "tel:+1-816-555-1212",
   "scheme": "tel",
   "path": "+1-816-555-1212",
-  "path-segments": array { "+1-816-555-1212" }
+  "path-segments": "+1-816-555-1212"
 })</test>
     <result><assert-eq>"tel:+1-816-555-1212"</assert-eq></result>
   </test-case>
@@ -365,7 +367,7 @@
   "host": "192.0.2.16",
   "port": "80",
   "path": "/",
-  "path-segments": array { "", "" }
+  "path-segments": ("", "")
 })</test>
     <result><assert-eq>"telnet://192.0.2.16:80/"</assert-eq></result>
   </test-case>
@@ -377,7 +379,7 @@
   "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
   "scheme": "urn",
   "path": "oasis:names:specification:docbook:dtd:xml:4.1.2",
-  "path-segments": array { "oasis:names:specification:docbook:dtd:xml:4.1.2" }
+  "path-segments": "oasis:names:specification:docbook:dtd:xml:4.1.2"
 })</test>
     <result><assert-eq>"urn:oasis:names:specification:docbook:dtd:xml:4.1.2"</assert-eq></result>
   </test-case>
@@ -389,7 +391,7 @@
     "uri": "tag:textalign.net,2015:ns",
     "scheme": "tag",
     "path": "textalign.net,2015:ns",
-    "path-segments": [ "textalign.net,2015:ns" ]
+    "path-segments": ("textalign.net,2015:ns")
   })</test>
     <result>
       <assert-eq>"tag:textalign.net,2015:ns"</assert-eq>
@@ -403,7 +405,7 @@
     "uri": "tag:jan@example.com,1999-01-31:my-uri",
     "scheme": "tag",
     "path": "jan@example.com,1999-01-31:my-uri",
-    "path-segments": [ "jan@example.com,1999-01-31:my-uri" ]
+    "path-segments": ("jan@example.com,1999-01-31:my-uri")
 })</test>
     <result><assert-eq>"tag:jan@example.com,1999-01-31:my-uri"</assert-eq></result>
   </test-case>
@@ -415,7 +417,7 @@
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
   "scheme": "jar",
   "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
-  "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
+  "path-segments": ("file:", "C:", "Program Files", "test.jar!", "foo", "bar")
 })</test>
     <result>
       <any-of>
@@ -434,7 +436,7 @@
     "authority": "www.example.org",
     "host": "www.example.org",
     "path": "/Dürst",
-    "path-segments": [ "","Dürst" ]
+    "path-segments": ("", "Dürst")
 })</test>
     <result><assert-eq>"http://www.example.org/Dürst"</assert-eq></result>
   </test-case>
@@ -450,16 +452,18 @@
   "port": "8080",
   "path": "/path",
   "query": "s=%22hello world%22;sort=relevance",
-  "query-segments": array {
-    map { "key": "s", "value": """hello world""" },
-    map { "key": "sort", "value": "relevance" }
+  "query-parameters": map {
+    "s": """hello world""",
+    "sort": "relevance"
   },
-  "path-segments": array { "", "path" }
+  "path-segments": ("", "path")
 }, map { 'query-separator': ';' })</test>
     <result>
       <any-of>
-        <assert-eq>"https://example.com:8080/path?s=%22hello+world%22;sort=relevance"</assert-eq>
         <assert-eq>'https://example.com:8080/path?s="hello+world";sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="hello%20world";sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="sort=relevance;hello+world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s="sort=relevance;hello%20world"'</assert-eq>
       </any-of>
     </result>
   </test-case>
@@ -473,7 +477,7 @@
                            'userinfo': 'user:password',
                            'host': 'example.com',
                            'port': '443',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'},
                         map { 'allow-deprecated-features': true() })</test>
     <result><assert-eq>"https://user:password@example.com:443/path"</assert-eq></result>
@@ -487,7 +491,7 @@
                            'authority': 'user:password@example.com:443',
                            'host': 'example.com',
                            'port': '443',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'}, map { 'omit-default-ports': true() })</test>
     <result><assert-eq>"https://example.com/path"</assert-eq></result>
   </test-case>
@@ -508,7 +512,7 @@
     <created by="Norm Tovey-Walsh" on="2023-03-08"/>
     <test>fn:build-uri(map {'scheme': 'https',
                             'host': 'example.com',
-                            'path-segments': ['', 'path','to','file'],
+                            'path-segments': ('', 'path','to','file'),
                             'path': '/wont/be/used'}, map { })</test>
     <result>
       <assert-eq>'https://example.com/path/to/file'</assert-eq>
@@ -520,15 +524,22 @@
     <created by="Norm Tovey-Walsh" on="2023-03-08"/>
     <test>fn:build-uri(map {'scheme': 'https',
                             'host': 'example.com',
-                            'path-segments': ['', 'path','to','file'],
-                            'query-segments': [
-                              map { 'key': 'key1', 'value': 'value1' },
-                              map { 'key': 'key2' },
-                              map { 'value': 'value3'},
-                              map { 'something': 'else', 'is': 'ignored' }
-                            ]}, map { })</test>
+                            'path-segments': ('', 'path','to','file'),
+                            'query-parameters': map {
+                              'key1': 'value1',
+                              'key2': '',
+                              '': 'value3'
+                             }
+                            }, map { })</test>
     <result>
-      <assert-eq>`https://example.com/path/to/file?key1=value1&amp;key2&amp;value3`</assert-eq>
+      <any-of>
+        <assert-eq>"https://example.com/path/to/file?key1=value1&amp;key2=&amp;value3"</assert-eq>
+        <assert-eq>"https://example.com/path/to/file?key1=value1&amp;value3&amp;key2="</assert-eq>
+        <assert-eq>"https://example.com/path/to/file?key2=&amp;key1=value1&amp;value3"</assert-eq>
+        <assert-eq>"https://example.com/path/to/file?key2=&amp;value3&amp;key1=value1"</assert-eq>
+        <assert-eq>"https://example.com/path/to/file?value3&amp;key1=value1&amp;key2="</assert-eq>
+        <assert-eq>"https://example.com/path/to/file?value3&amp;key2=&amp;key1=value1"</assert-eq>
+      </any-of>
     </result>
   </test-case>
 
@@ -540,15 +551,16 @@
       let $amp := codepoints-to-string(38) return
       fn:build-uri(map {'scheme': 'https',
                             'host': 'example.com',
-                            'path-segments': ['', 'path to','a/b','file'],
-                            'query-segments': [
-                              map { 'key': 'ke=y1', 'value': 'val'||$amp||'ue1' },
-                              map { 'key': 'ke?y2', 'value': 'val''ue2' }
-                            ]}, map { }) ]]></test>
+                            'path-segments': ('', 'path to', 'a/b', 'file'),
+                            'query-parameters': map {
+                              'ke=y1': 'val'||$amp||'ue1',
+                              'ke?y2': 'val''ue2'
+                            }
+                       }, map { }) ]]></test>
     <result>
       <any-of>
-        <assert-eq>`https://example.com/path+to/a%2fb/file?ke%3dy1=val%26ue1&amp;ke%3fy2=val%27ue2`</assert-eq>
-        <assert-eq>`https://example.com/path+to/a%2Fb/file?ke%3Dy1=val%26ue1&amp;ke%3Fy2=val%27ue2`</assert-eq>
+        <assert-eq>"https://example.com/path+to/a%2fb/file?ke%3dy1=val%26ue1&amp;ke%3fy2=val%27ue2"</assert-eq>
+        <assert-eq>"https://example.com/path+to/a%2Fb/file?ke%3Dy1=val%26ue1&amp;ke%3Fy2=val%27ue2"</assert-eq>
       </any-of>
     </result>
   </test-case>
@@ -558,7 +570,7 @@
     <created by="Norm Tovey-Walsh" on="2023-03-08"/>
     <test>fn:build-uri(map {'scheme': 'https',
                             'host': 'example.com',
-                            'path-segments': ['', 'path to','a/b','file'],
+                            'path-segments': ('', 'path to','a/b','file'),
                             'fragment': 'frag id'
                            }, map { })</test>
     <result>
@@ -574,14 +586,14 @@
     <created by="Norm Tovey-Walsh" on="2023-03-08"/>
     <test>fn:build-uri(map {'scheme': 'https',
                             'host': 'example.com',
-                            'path-segments': ['', 'path','to','file'],
-                            'query-segments': [
-                              map { 'key': 'key1', 'value': 'value1' },
-                              map { 'key': 'key2', 'value': 'value2' }
-                            ],
+                            'path-segments': ('', 'path','to','file'),
+                            'query-parameters': map {
+                              'key1': 'value1',
+                              'key2': 'value2'
+                            },
                             'fragment': 'fragid'}, map { })</test>
     <result>
-      <assert-eq>`https://example.com/path/to/file?key1=value1&amp;key2=value2#fragid`</assert-eq>
+      <assert-eq>"https://example.com/path/to/file?key1=value1&amp;key2=value2#fragid"</assert-eq>
     </result>
   </test-case>
 
@@ -589,7 +601,7 @@
     <description>Constructs an hierarchical URI with an unknown scheme</description>
     <created by="Norm Tovey-Walsh" on="2023-03-12"/>
     <test>fn:build-uri(map {'scheme': 'querty',
-                            'path-segments': ['', 'abc'],
+                            'path-segments': ('', 'abc'),
                             'path': 'abc'}, map { })</test>
     <result>
       <assert-eq>"querty:///abc"</assert-eq>
@@ -601,7 +613,7 @@
     <created by="Norm Tovey-Walsh" on="2023-03-12"/>
     <test>fn:build-uri(map {'scheme': 'querty',
                             'hierarchical': false(),
-                            'path-segments': ['abc'],
+                            'path-segments': ('abc'),
                             'path': 'abc'}, map { })</test>
     <result>
       <assert-eq>"querty:abc"</assert-eq>

--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -16,7 +16,7 @@
         "authority": "example.com",
         "host": "example.com",
         "path": "/path/to/file",
-        "path-segments": [ "", "path", "to", "file" ],
+        "path-segments": ("", "path", "to", "file"),
         "scheme": "https",
         "hierarchical": true(),
         "uri": "https://example.com\path\to\file"
@@ -35,7 +35,7 @@
                            'authority': 'user:password@example.com:443',
                            'host': 'example.com',
                            'port': '443',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'}</assert-deep-eq>
     </result>
   </test-case>
@@ -65,7 +65,7 @@
                            'authority': 'user:password@example.com:443',
                            'port': '443',
                            'host': 'example.com',
-                           'path-segments': ['','path','a/b','a b'],
+                           'path-segments': ('','path','a/b','a b'),
                            'path': '/path/a%2fb/a+b'}</assert-deep-eq>
     </result>
   </test-case>
@@ -80,7 +80,7 @@
         "fragment": "parse-uri",
         "host": "qt4cg.org",
         "path": "/specifications/xpath-functions-40/Overview.html",
-        "path-segments": [ "", "specifications", "xpath-functions-40", "Overview.html" ],
+        "path-segments": ("", "specifications", "xpath-functions-40", "Overview.html"),
         "scheme": "https",
         "hierarchical": true(),
         "uri": "https://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
@@ -100,7 +100,7 @@
   "authority": "www.ietf.org",
   "host": "www.ietf.org",
   "path": "/rfc/rfc2396.txt",
-  "path-segments": array { "", "rfc", "rfc2396.txt" }
+  "path-segments": ("", "rfc", "rfc2396.txt")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -117,7 +117,7 @@
   "authority": "example.com",
   "host": "example.com",
   "path": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -132,19 +132,19 @@
     <result>
       <assert-deep-eq><![CDATA[
 map {
-  "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
+  "uri": "https://example.com:8080/path?s=%22hello world%22&sort=relevance",
   "scheme": "https",
   "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
   "port": "8080",
   "path": "/path",
-  "query": "s=%22hello world%22&amp;sort=relevance",
-  "query-segments": array {
-    map { "key": "s", "value": """hello world""" },
-    map { "key": "sort", "value": "relevance" }
+  "query": "s=%22hello world%22&sort=relevance",
+  "query-parameters": map {
+    "s": """hello world""",
+    "sort": "relevance"
   },
-  "path-segments": array { "", "path" }
+  "path-segments": ("", "path")
 }]]></assert-deep-eq>
     </result>
   </test-case>
@@ -162,7 +162,7 @@ map {
   "userinfo": "user",
   "host": "example.com",
   "path": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -179,7 +179,7 @@ map {
   "authority": "ftp.is.co.za",
   "host": "ftp.is.co.za",
   "path": "/rfc/rfc1808.txt",
-  "path-segments": array { "", "rfc", "rfc1808.txt" }
+  "path-segments": ("", "rfc", "rfc1808.txt")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -197,7 +197,7 @@ map {
   "host": "uncname",
   "path": "/path/to/file",
   "filepath": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -215,7 +215,7 @@ map {
   "host": "uncname",
   "path": "/path/to/file",
   "filepath": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -233,7 +233,7 @@ map {
   "host": "uncname",
   "path": "/path/to/file",
   "filepath": "//uncname/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -249,7 +249,7 @@ map {
   "hierarchical": true(),
   "path": "/c:/path/to/file",
   "filepath": "c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -265,7 +265,7 @@ map {
   "hierarchical": true(),
   "path": "/C:/Program%20Files/test.jar",
   "filepath": "C:/Program Files/test.jar",
-  "path-segments": array { "", "C:", "Program Files", "test.jar" }
+  "path-segments": ("", "C:", "Program Files", "test.jar")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -281,7 +281,7 @@ map {
   "hierarchical": true(),
   "path": "/c:/path/to/file",
   "filepath": "c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -297,7 +297,7 @@ map {
   "hierarchical": true(),
   "path": "/c:/path/to/file",
   "filepath": "c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -313,7 +313,7 @@ map {
   "hierarchical": true(),
   "path": "/c:/path/to/file",
   "filepath": "c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -328,7 +328,7 @@ map {
   "uri": "/path/to/file",
   "path": "/path/to/file",
   "filepath": "/path/to/file",
-  "path-segments": array { "", "path", "to", "file" }
+  "path-segments": ("", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -353,8 +353,8 @@ map {
       <assert-deep-eq>map {
   "uri": "?q=1",
   "query": "q=1",
-  "query-segments": array {
-    map { "key": "q", "value": "1" }
+  "query-parameters": map {
+    "q": "1"
   }
 }</assert-deep-eq>
     </result>
@@ -373,10 +373,10 @@ map {
   "host": "[2001:db8::7]",
   "path": "/c=GB",
   "query": "objectClass?one",
-  "query-segments": array {
-    map { "value": "objectClass?one" }
+  "query-parameters": map {
+    "": "objectClass?one"
   },
-  "path-segments": array { "", "c=GB" }
+  "path-segments": ("", "c=GB")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -391,7 +391,7 @@ map {
   "scheme": "mailto",
   "hierarchical": false(),
   "path": "John.Doe@example.com",
-  "path-segments": array { "John.Doe@example.com" }
+  "path-segments": "John.Doe@example.com"
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -406,7 +406,7 @@ map {
   "scheme": "news",
   "hierarchical": false(),
   "path": "comp.infosystems.www.servers.unix",
-  "path-segments": array { "comp.infosystems.www.servers.unix" }
+  "path-segments": "comp.infosystems.www.servers.unix"
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -423,14 +423,14 @@ map {
            "scheme": "tel",
            "hierarchical": false(),
            "path": "+1-816-555-1212",
-           "path-segments": array { "+1-816-555-1212" }
+           "path-segments": "+1-816-555-1212"
         }</assert-deep-eq>
         <assert-deep-eq>map {
            "uri": "tel:+1-816-555-1212",
            "scheme": "tel",
            "hierarchical": false(),
            "path": "+1-816-555-1212",
-           "path-segments": array { " 1-816-555-1212" }
+           "path-segments": " 1-816-555-1212"
         }</assert-deep-eq>
       </any-of>
     </result>
@@ -449,7 +449,7 @@ map {
   "host": "192.0.2.16",
   "port": "80",
   "path": "/",
-  "path-segments": array { "", "" }
+  "path-segments": ("", "")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -464,7 +464,7 @@ map {
   "scheme": "urn",
   "hierarchical": false(),
   "path": "oasis:names:specification:docbook:dtd:xml:4.1.2",
-  "path-segments": array { "oasis:names:specification:docbook:dtd:xml:4.1.2" }
+  "path-segments": "oasis:names:specification:docbook:dtd:xml:4.1.2"
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -479,7 +479,7 @@ map {
     "scheme": "tag",
     "hierarchical": false(),
     "path": "textalign.net,2015:ns",
-    "path-segments": [ "textalign.net,2015:ns" ]
+    "path-segments": "textalign.net,2015:ns"
   }</assert-deep-eq>
     </result>
   </test-case>
@@ -494,7 +494,7 @@ map {
     "scheme": "tag",
     "hierarchical": false(),
     "path": "jan@example.com,1999-01-31:my-uri",
-    "path-segments": [ "jan@example.com,1999-01-31:my-uri" ]
+    "path-segments": "jan@example.com,1999-01-31:my-uri"
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -509,7 +509,7 @@ map {
   "scheme": "jar",
   "hierarchical": false(),
   "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
-  "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
+  "path-segments": ("file:", "C:", "Program Files", "test.jar!", "foo", "bar")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -526,7 +526,7 @@ map {
     "authority": "www.example.org",
     "host": "www.example.org",
     "path": "/Dürst",
-    "path-segments": [ "","Dürst" ]
+    "path-segments": ("","Dürst")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -545,11 +545,11 @@ map {
   "port": "8080",
   "path": "/path",
   "query": "s=%22hello world%22;sort=relevance",
-  "query-segments": array {
-    map { "key": "s", "value": """hello world""" },
-    map { "key": "sort", "value": "relevance" }
+  "query-parameters": map {
+    "s": """hello world""",
+    "sort": "relevance"
   },
-  "path-segments": array { "", "path" }
+  "path-segments": ("", "path")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -567,7 +567,7 @@ map {
                            'userinfo': 'user:password',
                            'host': 'example.com',
                            'port': '443',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'}</assert-deep-eq>
     </result>
   </test-case>
@@ -583,7 +583,7 @@ map {
                            "hierarchical": true(),
                            'authority': 'user:password@example.com:443',
                            'host': 'example.com',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'}</assert-deep-eq>
     </result>
   </test-case>
@@ -602,7 +602,7 @@ map {
                            'authority': 'user:password@example.com:443',
                            'userinfo': 'user:password',
                            'host': 'example.com',
-                           'path-segments': ['', 'path'],
+                           'path-segments': ('', 'path'),
                            'path': '/path'}</assert-deep-eq>
     </result>
   </test-case>
@@ -615,7 +615,7 @@ map {
       <assert-deep-eq>map {'uri': 'querty:abc',
                            'scheme': 'querty',
                            'hierarchical': false(),
-                           'path-segments': ['abc'],
+                           'path-segments': 'abc',
                            'path': 'abc'}</assert-deep-eq>
     </result>
   </test-case>
@@ -629,13 +629,13 @@ map {
         <assert>$result?uri eq 'querty:///abc'</assert>
         <assert>$result?scheme eq 'querty'</assert>
         <assert>$result?hierarchical</assert>
-        <assert>deep-equal($result?path-segments, ['', 'abc'])</assert>
+        <assert>deep-equal($result?path-segments, ('', 'abc'))</assert>
         <assert>$result?path eq '/abc'</assert>
       </all-of>
       <!--<assert-deep-eq>map {'uri': 'querty:///abc',
                            'scheme': 'querty',
                            "hierarchical": true(),
-                           'path-segments': ['', 'abc'],
+                           'path-segments': ('', 'abc'),
                            'path': '/abc'}</assert-deep-eq>-->
     </result>
   </test-case>
@@ -654,14 +654,13 @@ map {
   "authority": "example.com:8080",
   "path": "/path",
   "scheme": "https",
-  "query-segments":[
-    map {"value": """hello world""",
-         "key":"s"},
-    map {"value":"relevance",
-         "key":"sort"}],
-  "path-segments": ["","path"],
-  "query": "s=%22hello world%22&amp;sort=relevance",
-  "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance"
+  "query-parameters": map {
+    "s": """hello world""",
+    "sort": "relevance"
+   },
+  "path-segments": ("", "path"),
+  "query": "s=%22hello world%22&sort=relevance",
+  "uri": "https://example.com:8080/path?s=%22hello world%22&sort=relevance"
 }]]></assert-deep-eq>
     </result>
   </test-case>
@@ -677,7 +676,7 @@ map {
   "hierarchical": true(),
   "path": "/c:/path/to/file",
   "filepath": "c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>
@@ -693,7 +692,7 @@ map {
   "hierarchical": true(),
   "path": "/c:/path/to/file",
   "filepath": "c:/path/to/file",
-  "path-segments": array { "", "c:", "path", "to", "file" }
+  "path-segments": ("", "c:", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>


### PR DESCRIPTION
This PR changes the arrays in `parse-uri` output (and `build-uri` input) to sequences.

(This is speculative as I haven't implemented the changes yet.)