### PR TITLE
Fixes for fn:parse-uri and fn:build-uri

### DIFF
--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -130,8 +130,12 @@
       <any-of>
         <assert-eq>'https://example.com:8080/path?s="hello+world"&amp;sort=relevance'</assert-eq>
         <assert-eq>'https://example.com:8080/path?s="hello%20world"&amp;sort=relevance'</assert-eq>
-        <assert-eq>'https://example.com:8080/path?s="sort=relevance&amp;hello+world"'</assert-eq>
-        <assert-eq>'https://example.com:8080/path?s="sort=relevance&amp;hello%20world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance&amp;"hello+world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance&amp;"hello%20world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=%22hello+world%22&amp;sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=%22hello%20world%22&amp;sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance&amp;%22hello+world%22'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance&amp;%22hello%20world%22'</assert-eq>
       </any-of>
     </result>
   </test-case>
@@ -462,8 +466,12 @@
       <any-of>
         <assert-eq>'https://example.com:8080/path?s="hello+world";sort=relevance'</assert-eq>
         <assert-eq>'https://example.com:8080/path?s="hello%20world";sort=relevance'</assert-eq>
-        <assert-eq>'https://example.com:8080/path?s="sort=relevance;hello+world"'</assert-eq>
-        <assert-eq>'https://example.com:8080/path?s="sort=relevance;hello%20world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance;"hello+world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance;"hello%20world"'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=%22hello+world%22;sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=%22hello%20world%22;sort=relevance'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance;%22hello+world%22'</assert-eq>
+        <assert-eq>'https://example.com:8080/path?s=sort=relevance;%22hello%20world%22'</assert-eq>
       </any-of>
     </result>
   </test-case>

--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -723,7 +723,7 @@ map {
   "hierarchical": false(),
   "filepath": "�00",
   "path": "%FF00",
-  "path-segments": ["�00"]
+  "path-segments": "�00"
 }</assert-deep-eq>
     </result>
   </test-case>


### PR DESCRIPTION
1. There are some typos with respect to where `"` appears in the results of a couple of `fn:build-uri` tests. I've also changed the test so that either `"` or `%22` is accepted. I can't find any motivation in RFC 3986 to encode `"`, but it's often done.
2. In the `fn:parse-uri` tests, when we changed from arrays to sequences, the square brackets were accidentally left in test 041.