### PR TITLE
Test for parsing repeated query parameters

### DIFF
--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -728,4 +728,24 @@ map {
     </result>
   </test-case>
 
+  <test-case name="fn-parse-uri-042">
+    <description>Tests that repeated query parameters are represented as a sequence.</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-24"/>
+    <test><![CDATA[fn:parse-uri("http://example.com/path?a=1&amp;b=2%264&amp;a=3")]]></test>
+    <result>
+      <assert-deep-eq><![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'uri': 'http://example.com/path?a=1&b=2%264&a=3',
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           'path-segments': ('','path'),
+                           'path': '/path',
+                           "query":"a=1&b=2%264&a=3",
+                           "query-parameters": map {
+                             "a": ("1", "3"),
+                             "b": "2&4"
+                           }}]]></assert-deep-eq>
+    </result>
+  </test-case>
+
 </test-set>


### PR DESCRIPTION
Discovered this test was missing while cleaning up the spec.

(I haven't attempted to sort out the `&` problems with backticks yet, but it's on my list.)