### PR TITLE
Comprehensive encoding/decoding tests

### DIFF
--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -655,7 +655,7 @@
                            "fragment": " !""#$%&amp;'()*+,-./0123456789:;&lt;=>?"
                          }]]>)</test>
     <result>
-      <assert-eq>"http://example.com/%20!%22%23$%25&amp;'()*+,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*+,-&amp;b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&amp;'()*+,-./0123456789:;%3C=%3E?"</assert-eq>
+      <assert-eq>`http://example.com/%20!%22%23$%25&amp;'()*+,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*+,-&amp;b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&amp;'()*+,-./0123456789:;%3C=%3E?`</assert-eq>
     </result>
   </test-case>
 
@@ -674,7 +674,7 @@
                            "fragment": "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"
                          }]]>)</test>
     <result>
-      <assert-eq>"http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&amp;b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_"</assert-eq>
+      <assert-eq>`http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&amp;b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_`</assert-eq>
     </result>
   </test-case>
 
@@ -693,7 +693,7 @@
                            "fragment": "`abcdefghijklmnopqrstuvwxyz{|}~"
                          }]]>)</test>
     <result>
-    <assert-eq>"http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&amp;b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~"</assert-eq>
+    <assert-eq>`http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&amp;b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~`</assert-eq>
     </result>
   </test-case>
 
@@ -711,7 +711,9 @@
                            },
                            "fragment": "🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿"
                          }]]>)</test>
-    <result><assert-eq>"http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&amp;b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿"</assert-eq></result>
+    <result>
+      <assert-eq>`http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&amp;b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿`</assert-eq>
+    </result>
   </test-case>
 
 </test-set>

--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -640,5 +640,79 @@
     <result><assert-eq>"http://example.com/path?a=1&amp;a=3&amp;b=2%264"</assert-eq></result>
   </test-case>
 
+  <test-case name="fn-build-uri-010a">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:build-uri(<![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           'path-segments': ('',' !"#$%&amp;''()*+,-./0123456789:;&lt;=>?'),
+                           "query-parameters": map {
+                             "a": (" !""#$%&amp;'()*+,-"),
+                             "b": ("./0123456789:;&lt;=>?")
+                           },
+                           "fragment": " !""#$%&amp;'()*+,-./0123456789:;&lt;=>?"
+                         }]]>)</test>
+    <result>
+      <assert-eq>"http://example.com/%20!%22%23$%25&amp;'()*+,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*+,-&amp;b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&amp;'()*+,-./0123456789:;%3C=%3E?"</assert-eq>
+    </result>
+  </test-case>
+
+  <test-case name="fn-build-uri-010b">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:build-uri(<![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           'path-segments': ('','@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_'),
+                           "query-parameters": map {
+                             "a": ("@ABCDEFGHIJKLMN"),
+                             "b": ("OPQRSTUVWXYZ[\]^_")
+                           },
+                           "fragment": "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"
+                         }]]>)</test>
+    <result>
+      <assert-eq>"http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&amp;b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_"</assert-eq>
+    </result>
+  </test-case>
+
+  <test-case name="fn-build-uri-010c">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:build-uri(<![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           'path-segments': ('','`abcdefghijklmnopqrstuvwxyz{|}~'),
+                           "query-parameters": map {
+                             "a": ("`abcdefghijklmn"),
+                             "b": ("opqrstuvwxyz{|}~")
+                           },
+                           "fragment": "`abcdefghijklmnopqrstuvwxyz{|}~"
+                         }]]>)</test>
+    <result>
+    <assert-eq>"http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&amp;b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~"</assert-eq>
+    </result>
+  </test-case>
+
+  <test-case name="fn-build-uri-010d">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:build-uri(<![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           'path-segments': ('','🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿'),
+                           "query-parameters": map {
+                             "a": ("🤷 ¡¢£¤ǌ"),
+                             "b": ("†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿")
+                           },
+                           "fragment": "🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿"
+                         }]]>)</test>
+    <result><assert-eq>"http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&amp;b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿"</assert-eq></result>
+  </test-case>
+
 </test-set>
 

--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -757,15 +757,15 @@ map {
                            "hierarchical": true(),
                            'authority': 'example.com',
                            'host': 'example.com',
-                           "path": '/%20!%22%23$%25&''()*%2B,-.%2F0123456789:;%3C=%3E%3F',
-                           'path-segments': ('',' !"#$%25&''()*+,-./0123456789:;<=>?'),
-                           'query': 'a=%20!%22%23$%25%26''()*%2B,-&b=./0123456789:;%3C%3D%3E?',
+                           "path": `/%20!%22%23$%25&'()*%2B,-.%2F0123456789:;%3C=%3E%3F`,
+                           'path-segments': ('',` !"#$%&'()*+,-./0123456789:;<=>?`),
+                           'query': `a=%20!%22%23$%25%26'()*%2B,-&b=./0123456789:;%3C%3D%3E?`,
                            'query-parameters': map {
-                             'a': (' !"#$%25&''()*+,-'),
+                             'a': (` !"#$%&'()*+,-`),
                              'b': ('./0123456789:;<=>?')
                            },
-                           'fragment': ' !"#$%25&''()*+,-./0123456789:;<=>?',
-                           'uri': 'http://example.com/%20!%22%23$%25&''()*%2B,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26''()*%2B,-&b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&''()*%2B,-./0123456789:;%3C=%3E?'
+                           'fragment': ` !"#$%&'()*+,-./0123456789:;<=>?`,
+                           'uri': `http://example.com/%20!%22%23$%25&'()*%2B,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*%2B,-&b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&'()*%2B,-./0123456789:;%3C=%3E?`
                          }]]></assert-deep-eq>
     </result>
   </test-case>
@@ -781,13 +781,13 @@ map {
                            'host': 'example.com',
                            "path": '/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_',
                            'path-segments': ('','@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_'),
-                           'query': 'a=@ABCDEFGHIJKLMN&b=OPQRSTUVWXYZ%5B%5C%5D%5E_',
+                           'query': `a=@ABCDEFGHIJKLMN&b=OPQRSTUVWXYZ%5B%5C%5D%5E_`,
                            'query-parameters': map {
                              'a': ('@ABCDEFGHIJKLMN'),
                              'b': ('OPQRSTUVWXYZ[\]^_')
                            },
                            'fragment': '@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_',
-                           'uri': 'http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_'
+                           'uri': `http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_`
                          }]]></assert-deep-eq>
     </result>
   </test-case>
@@ -803,13 +803,13 @@ map {
                            'host': 'example.com',
                            "path": '/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~',
                            'path-segments': ('','`abcdefghijklmnopqrstuvwxyz{|}~'),
-                           'query': 'a=%60abcdefghijklmn&b=opqrstuvwxyz%7B%7C%7D~',
+                           'query': `a=%60abcdefghijklmn&b=opqrstuvwxyz%7B%7C%7D~`,
                            "query-parameters": map {
                              "a": ("`abcdefghijklmn"),
                              "b": ("opqrstuvwxyz{|}~")
                            },
                            "fragment": "`abcdefghijklmnopqrstuvwxyz{|}~",
-                           'uri': 'http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~'
+                           'uri': `http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~`
                          }]]></assert-deep-eq>
     </result>
   </test-case>
@@ -825,13 +825,13 @@ map {
                            'host': 'example.com',
                            "path": '/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿',
                            'path-segments': ('','🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿'),
-                           'query': 'a=🤷 ¡¢£¤ǌ&b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿',
+                           'query': `a=🤷 ¡¢£¤ǌ&b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿`,
                            "query-parameters": map {
                              "a": "🤷 ¡¢£¤ǌ",
                              "b": "†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿"
                            },
                            "fragment": "🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿",
-                           'uri': 'http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿'
+                           'uri': `http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿`
                          }]]></assert-deep-eq>
     </result>
   </test-case>

--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -748,4 +748,91 @@ map {
     </result>
   </test-case>
 
+  <test-case name="fn-parse-uri-043a">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:parse-uri(`http://example.com/%20!%22%23$%25&amp;'()*%2B,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*%2B,-&amp;b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&amp;'()*%2B,-./0123456789:;%3C=%3E?`)</test>
+    <result>
+      <assert-deep-eq><![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           "path": '/%20!%22%23$%25&''()*%2B,-.%2F0123456789:;%3C=%3E%3F',
+                           'path-segments': ('',' !"#$%25&''()*+,-./0123456789:;<=>?'),
+                           'query': 'a=%20!%22%23$%25%26''()*%2B,-&b=./0123456789:;%3C%3D%3E?',
+                           'query-parameters': map {
+                             'a': (' !"#$%25&''()*+,-'),
+                             'b': ('./0123456789:;<=>?')
+                           },
+                           'fragment': ' !"#$%25&''()*+,-./0123456789:;<=>?',
+                           'uri': 'http://example.com/%20!%22%23$%25&''()*%2B,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26''()*%2B,-&b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&''()*%2B,-./0123456789:;%3C=%3E?'
+                         }]]></assert-deep-eq>
+    </result>
+  </test-case>
+
+  <test-case name="fn-parse-uri-043b">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:parse-uri(`http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&amp;b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_`)</test>
+    <result>
+      <assert-deep-eq><![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           "path": '/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_',
+                           'path-segments': ('','@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_'),
+                           'query': 'a=@ABCDEFGHIJKLMN&b=OPQRSTUVWXYZ%5B%5C%5D%5E_',
+                           'query-parameters': map {
+                             'a': ('@ABCDEFGHIJKLMN'),
+                             'b': ('OPQRSTUVWXYZ[\]^_')
+                           },
+                           'fragment': '@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_',
+                           'uri': 'http://example.com/@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_?a=@ABCDEFGHIJKLMN&b=OPQRSTUVWXYZ%5B%5C%5D%5E_#@ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_'
+                         }]]></assert-deep-eq>
+    </result>
+  </test-case>
+
+  <test-case name="fn-parse-uri-043c">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:parse-uri(`http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&amp;b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~`)</test>
+    <result>
+      <assert-deep-eq><![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           "path": '/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~',
+                           'path-segments': ('','`abcdefghijklmnopqrstuvwxyz{|}~'),
+                           'query': 'a=%60abcdefghijklmn&b=opqrstuvwxyz%7B%7C%7D~',
+                           "query-parameters": map {
+                             "a": ("`abcdefghijklmn"),
+                             "b": ("opqrstuvwxyz{|}~")
+                           },
+                           "fragment": "`abcdefghijklmnopqrstuvwxyz{|}~",
+                           'uri': 'http://example.com/%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~?a=%60abcdefghijklmn&b=opqrstuvwxyz%7B%7C%7D~#%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~'
+                         }]]></assert-deep-eq>
+    </result>
+  </test-case>
+
+  <test-case name="fn-parse-uri-043d">
+    <description>Tests character encoding</description>
+    <created by="Norm Tovey-Walsh" on="2023-10-26"/>
+    <test>fn:parse-uri(`http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&amp;b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿`)</test>
+    <result>
+      <assert-deep-eq><![CDATA[map {'scheme': 'http',
+                           "hierarchical": true(),
+                           'authority': 'example.com',
+                           'host': 'example.com',
+                           "path": '/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿',
+                           'path-segments': ('','🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿'),
+                           'query': 'a=🤷 ¡¢£¤ǌ&b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿',
+                           "query-parameters": map {
+                             "a": "🤷 ¡¢£¤ǌ",
+                             "b": "†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿"
+                           },
+                           "fragment": "🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿",
+                           'uri': 'http://example.com/🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿?a=🤷 ¡¢£¤ǌ&b=†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿#🤷 ¡¢£¤ǌ†𓇌𓆑🏴󠁧󠁢󠁷󠁬󠁳󠁿'
+                         }]]></assert-deep-eq>
+    </result>
+  </test-case>
 </test-set>


### PR DESCRIPTION
This PR adds a comprehensive set of tests for encoding and decoding characters in URIs. All of the characters from space (`%20`) to ~ (`%7E`) and a range of higher Unicode characters and emoji are included. This should assure that implementations get consistent results for both parsing URIs (and decoding the parts of the URI) and building URIs (and encoding the parts of the URI).

The test results are (to the best of my knowledge at the moment) correct and consistent with both `fn:decode-for-uri` and the notes in https://github.com/qt4cg/qtspecs/issues/774

(I hope I've encoded the tests so that they work with the XQuery driver; apologies if I messed up anywhere. I'd be very interested in hearing what differences, if any, other implementations give.)