### PR TITLE
Add alternate results to format-time-021 and format-time-022

### DIFF
--- a/fn/format-time.xml
+++ b/fn/format-time.xml
@@ -393,11 +393,13 @@
       <description>Test format-time: am/Am/AM</description>
       <created by="Josh Spiegel" on="2016-03-11"/>
       <modified by="Debbie Lockett, Saxonica" on="2016-05-04" change="Add alternate results (bug 29599)"/>
+      <modified by="Gunther Rademacher" on="2024-01-26" change="Add alternate results (BaseXdb/basex#2273)"/>
       <test>format-time(xs:time('09:15:06.456'),"[Pn]/[PNn]/[PN]")</test>
       <result>
          <any-of>
             <assert-string-value>am/Am/AM</assert-string-value>
             <assert-string-value>a.m./A.M./A.M.</assert-string-value>
+            <assert-string-value>am/AM/AM</assert-string-value>
          </any-of>
       </result>
    </test-case>
@@ -406,11 +408,13 @@
       <description>Test format-time: pm/Pm/PM</description>
       <created by="Josh Spiegel" on="2016-03-11"/>
       <modified by="Debbie Lockett, Saxonica" on="2016-05-04" change="Add alternate results (bug 29599)"/>
+      <modified by="Gunther Rademacher" on="2024-01-26" change="Add alternate results (BaseXdb/basex#2273)"/>
       <test>format-time(xs:time('15:15:06.456'),"[Pn]/[PNn]/[PN]")</test>
       <result>
          <any-of>
             <assert-string-value>pm/Pm/PM</assert-string-value>
             <assert-string-value>p.m./P.M./P.M.</assert-string-value>
+            <assert-string-value>pm/PM/PM</assert-string-value>
          </any-of>
       </result>
    </test-case>


### PR DESCRIPTION
In date/time formatting, BaseX used to generate mixed case AM/PM and era indicators as `Am`, `Pm`, `Bc`, `Ad`. This is about to be changed to `AM`, `PM`, `BC`, `AD` (see BaseXdb/basex#2273), which consequently requires alternate results for test cases `format-time-021` and `format-time-022`.