### PR TITLE
Test fail-on-error on parser function rather than on parser generator

### DIFF
--- a/fn/invisible-xml.xml
+++ b/fn/invisible-xml.xml
@@ -46,9 +46,37 @@
    <test-case name="invisible-xml-902">
       <description>Bad grammar, fail-on-error=false</description>
       <created by="Michael Kay" on="2024-02-02"/>
+      <modified by="Gunther Rademacher" on="2024-02-05" change="expect error code FOIX0001"/>
       <test>invisible-xml("(((((", map{"fail-on-error":false()})</test>
       <result>
-         <assert>//@Q{http://invisiblexml.org/NS}state = 'failed'</assert>
+         <error code="FOIX0001"/>
+      </result>
+   </test-case>
+
+   <test-case name="invisible-xml-903">
+      <description>Bad input, fail-on-error=true</description>
+      <created by="Gunther Rademacher" on="2024-02-05"/>
+      <test>invisible-xml("S:.", map{"fail-on-error":true()})("-")</test>
+      <result>
+         <error code="FOIX0002"/>
+      </result>
+   </test-case>
+
+   <test-case name="invisible-xml-904">
+      <description>Bad input, fail-on-error=false</description>
+      <created by="Gunther Rademacher" on="2024-02-05"/>
+      <test>invisible-xml("S:.", map{"fail-on-error":false()})("-")</test>
+      <result>
+         <assert>$result//@Q{http://invisiblexml.org/NS}state = 'failed'</assert>
+      </result>
+   </test-case>
+
+   <test-case name="invisible-xml-905">
+      <description>Bad input, fail-on-error default</description>
+      <created by="Gunther Rademacher" on="2024-02-05"/>
+      <test>invisible-xml("S:.")("-")</test>
+      <result>
+         <assert>$result//@Q{http://invisiblexml.org/NS}state = 'failed'</assert>
       </result>
    </test-case>
 


### PR DESCRIPTION
Test case `invisible-xml-902` currently expects `fn:invisible-xml` to produce a document containing `status='failed'` upon an invalid grammar, when option `fail-on-error` is `false`. But according to the spec, option `fail-on-error` applies to the resulting parse function:

> If the fail-on-error option is true(), the parsing function will raise err:FOIX0002 if the input provided cannot be parsed successfully. Otherwise, it returns an XML representation of the error as described by the [[Invisible XML]](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#invisible-xml) specification.

It does not apply to the generator, which is supposed to always fail, when it is provided with an invalid grammar:

> If $grammar is not empty, it must be a valid Invisible XML grammar. If it is not, fn:invisible-xml raises err:FOIX0001.

(see [https://qt4cg.org/specifications/xpath-functions-40/Overview.html#func-invisible-xml](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#func-invisible-xml))

This is in line with the Invisible XML specification:

> A conforming processor must accept grammars in ixml form, and should accept grammars in XML form; it must not accept non-conforming grammars.

(see [https://invisiblexml.org/1.0/#processorconformance](https://invisiblexml.org/1.0/#processorconformance))

> If the parse fails, some XML document must be produced with ixml:state on the document element with a value that includes the word failed.

(see [https://invisiblexml.org/1.0/#parsing](https://invisiblexml.org/1.0/#parsing))

This change makes test case `invisible-xml-902` expect `err:FOIX0001` in this case, and it also adds test cases for `fail-on-error` with a valid grammar, but invalid input to the parser.