### PR TITLE
Add alternate result to format-integer-077 (fixes qt4cg/qt4tests#66)

### DIFF
--- a/fn/format-integer.xml
+++ b/fn/format-integer.xml
@@ -748,6 +748,7 @@
     <test-case name="format-integer-077">
         <description>format-integer - Cardinal number output request - German - using CLDR</description>
         <created by="Michael Kay" on="2022-12-02"/>
+        <modified by="Gunther Rademacher" on="2024-02-06" change="Add alternate results (qt4cg/qt4tests#66)"/>
         <dependency type="language" value="de"/>
         <dependency type="feature" value="fn-format-integer-CLDR"/>
         <test>format-integer(1, 'Ww;c(%spellout-ordinal-feminine)', 'de'),
@@ -755,7 +756,10 @@
             format-integer(1, 'Ww;c(%spellout-ordinal-r)', 'de'),
             format-integer(1, 'Ww;c(%spellout-ordinal-n)', 'de')</test>
         <result>
-            <assert-deep-eq>"Ein", "Erstes", "Erster", "Ersten"</assert-deep-eq>
+            <any-of>
+                <assert-deep-eq>"Ein", "Erstes", "Erster", "Ersten"</assert-deep-eq>
+                <assert-deep-eq>"Erste", "Erstes", "Erster", "Ersten"</assert-deep-eq>
+            </any-of>
         </result>    
     </test-case>
     


### PR DESCRIPTION
As pointed out in qt4cg/qt4tests#66, there may be more than one fallback strategy for ICU rule set names that cannot be matched exactly, and BaseX has chosen to implement one that does not match the expectation of test case [format-integer-077](https://github.com/qt4cg/qt4tests/blob/3392bd4e821b8434b2ff238004ddf6eb04ace891/fn/format-integer.xml#L748-L760).

This changes adds an alternate result, corresponding to BaseX behavior.