### PR TITLE
Fix upper-case mapping of '&#1011;'

### DIFF
--- a/fn/lower-case.xml
+++ b/fn/lower-case.xml
@@ -205,11 +205,12 @@
       </description>
       <created by="Michael Kay" on="2016-03-21"/>
       <modified by="O'Neil Delpratt" on="2016-03-04" change="Related to bug issue #29630 - Added unicode-version"/>
+	  <modified by="Gunther Rademacher" on="2024-02-18" change="Set lower-case mapping of 895 (&#x37F;) to 1011 (&#x3F3;)"/>
       <dependency type="unicode-version" value="7.0"/>
       <test>fn:string-to-codepoints(fn:lower-case(fn:codepoints-to-string(880 to 1023)))</test>
       <result>
          <assert-deep-eq>
-            881, 881, 883, 883, 884, 885, 887, 887, 888, 889, 890, 891, 892, 893, 894, 895, 896, 
+            881, 881, 883, 883, 884, 885, 887, 887, 888, 889, 890, 891, 892, 893, 894, 1011, 896, 
             897, 898, 899, 900, 901, 940, 903, 941, 942, 943, 907, 972, 909, 973, 974, 912, 945, 
             946, 947, 948, 949, 950, 951, 952, 953, 954, 955, 956, 957, 958, 959, 960, 961, 930, 
             963, 964, 965, 966, 967, 968, 969, 970, 971, 940, 941, 942, 943, 944, 945, 946, 947, 

--- a/fn/upper-case.xml
+++ b/fn/upper-case.xml
@@ -206,6 +206,7 @@
       </description>
       <created by="Michael Kay" on="2016-03-21"/>
       <modified by="O'Neil Delpratt" on="2016-03-04" change="Related to bug issue #29630 - Added unicode-version"/>
+      <modified by="Gunther Rademacher" on="2024-02-10" change="Set upper-case mapping of 1011 (&#x3F3;) to 895 (&#x37F;)"/>
       <dependency type="unicode-version" value="7.0"/>
       <test>fn:string-to-codepoints(fn:upper-case(fn:codepoints-to-string(880 to 1023)))</test>
       <result>
@@ -218,7 +219,7 @@
             928, 929, 931, 931, 932, 933, 934, 935, 936, 937, 938, 939, 908, 910, 911, 975, 914, 
             920, 978, 979, 980, 934, 928, 975, 984, 984, 986, 986, 988, 988, 990, 990, 992, 992, 
             994, 994, 996, 996, 998, 998, 1000, 1000, 1002, 1002, 1004, 1004, 1006, 1006, 922, 929, 
-            1017, 1011, 1012, 917, 1014, 1015, 1015, 1017, 1018, 1018, 1020, 1021, 1022, 1023</assert-deep-eq>
+            1017, 895, 1012, 917, 1014, 1015, 1015, 1017, 1018, 1018, 1020, 1021, 1022, 1023</assert-deep-eq>
       </result>
    </test-case>
    


### PR DESCRIPTION
Test `fn-upper-case-19` expects `fn:upper-case` to map `&#1011;` (`&#x3F3`) to itself. The test is marked with

```xml
<dependency type="unicode-version" value="7.0"/>
```

however Unicode version 7.0 has added `&#895;` (`&#x37F`) as the upper-case mapping (see [here](https://www.unicode.org/Public/7.0.0/ucd/UnicodeData.txt)).

Saxon 12.4 still maps to `&#1011;`, even though Java 11 maps to `&#895;` - does Saxon possibly maintain an out-of-date mapping?