### PR TITLE
Correct newly added fn:replace tests

### DIFF
--- a/fn/replace.xml
+++ b/fn/replace.xml
@@ -1488,8 +1488,9 @@ abracadabra", "\n",action := fn{"with"})</test>
    <test-case name="fn-replace-300">
       <description>Comments in regex.</description>
       <created by="Michael Kay" on="2024-02-13"/>
+      <modified by="Gunther Rademacher" on="2024-02-19" change="replace by $3-$1-$2, not $3-$2-$1"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>replace('02/17/2024', '(#month#..)/(#day#..)/(#year#....)', '$3-$2-$1', 'c')</test>
+      <test>replace('02/17/2024', '(#month#..)/(#day#..)/(#year#....)', '$3-$1-$2', 'c')</test>
       <result>
          <assert-string-value>2024-02-17</assert-string-value>
       </result>
@@ -1498,8 +1499,9 @@ abracadabra", "\n",action := fn{"with"})</test>
    <test-case name="fn-replace-301">
       <description>Escaped hash sign in regex.</description>
       <created by="Michael Kay" on="2024-02-13"/>
+      <modified by="Gunther Rademacher" on="2024-02-19" change="replace by $3-$1-$2, not $3-$2-$1"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>replace('#02/#17/#2024', '\#(#month#..)/\#(#day#..)/\#(#year#....)', '$3-$2-$1', 'c')</test>
+      <test>replace('#02/#17/#2024', '\#(#month#..)/\#(#day#..)/\#(#year#....)', '$3-$1-$2', 'c')</test>
       <result>
          <assert-string-value>2024-02-17</assert-string-value>
       </result>
@@ -1508,8 +1510,9 @@ abracadabra", "\n",action := fn{"with"})</test>
    <test-case name="fn-replace-302">
       <description>Escaped hash sign in regex.</description>
       <created by="Michael Kay" on="2024-02-13"/>
+      <modified by="Gunther Rademacher" on="2024-02-19" change="replace by $3-$1-$2, not $3-$2-$1"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>replace('#02/#17/#2024', '[#](#month#..)/[#](#day#..)/[#](#year#....)', '$3-$2-$1', 'c')</test>
+      <test>replace('#02/#17/#2024', '[#](#month#..)/[#](#day#..)/[#](#year#....)', '$3-$1-$2', 'c')</test>
       <result>
          <assert-string-value>2024-02-17</assert-string-value>
       </result>
@@ -1518,8 +1521,9 @@ abracadabra", "\n",action := fn{"with"})</test>
    <test-case name="fn-replace-303">
       <description>Comment runs to end of string.</description>
       <created by="Michael Kay" on="2024-02-13"/>
+      <modified by="Gunther Rademacher" on="2024-02-19" change="replace by $3-$1-$2, not $3-$2-$1"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>replace('02/17/2024', '(#month#..)/(#day#..)/(#year#....)# the end', '$3-$2-$1', 'c')</test>
+      <test>replace('02/17/2024', '(#month#..)/(#day#..)/(#year#....)# the end', '$3-$1-$2', 'c')</test>
       <result>
          <assert-string-value>2024-02-17</assert-string-value>
       </result>
@@ -1528,8 +1532,9 @@ abracadabra", "\n",action := fn{"with"})</test>
    <test-case name="fn-replace-304">
       <description>Adjacent comments in regex.</description>
       <created by="Michael Kay" on="2024-02-13"/>
+      <modified by="Gunther Rademacher" on="2024-02-19" change="replace by $3-$1-$2, not $3-$2-$1"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>replace('02/17/2024', '(#month#..)/(#day#..)/(#year##4 digits#....)', '$3-$2-$1', 'c')</test>
+      <test>replace('02/17/2024', '(#month#..)/(#day#..)/(#year##4 digits#....)', '$3-$1-$2', 'c')</test>
       <result>
          <assert-string-value>2024-02-17</assert-string-value>
       </result>


### PR DESCRIPTION
In some of the tests for `fn:replace`, that were added recently by be8f43b, the replacement string has a different order of components than the expected result.