### PR TITLE
Adapt test case hof-919 to new coercion rules

### DIFF
--- a/misc/HigherOrderFunctions.xml
+++ b/misc/HigherOrderFunctions.xml
@@ -603,11 +603,12 @@
       <description> numeric promotion works for various kinds of functions  </description>
       <created by="Michael Kay" on="2009-03-01"/>
       <modified by="Michael Kay" on="2011-01-03" change="see bug #15402"/>
-      <dependency type="spec" value="XQ30+"/>
+      <modified by="Gunther Rademacher" on="2024-03-11" change="reverted previous change as no longer necessary with XQ40+"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>
       declare function local:round($x as xs:double) as xs:double { fn:floor($x) }; 
       declare function local:ops() as (function(xs:double) as xs:double)* 
-      	{ (abs#1, local:round#1, function($x as xs:double){$x+1}, round-half-to-even(?, 2)) }; 
+      	{ (abs#1, local:round#1, function($x as xs:float){$x+1}, round-half-to-even(?, 2)) }; 
       string-join(for $f in local:ops() return string(round-half-to-even($f(xs:decimal('123.456')), 4)), '~')
       </test>
       <result>
@@ -994,24 +995,6 @@
         { $algorithm($x) }; 
         declare variable $roundToCeiling := local:round(?, upper-case#1); 
         $roundToCeiling(12.4)
-      </test>
-      <result>
-         <error code="XPTY0004"/>
-      </result>
-   </test-case>
-   
-   <test-case name="hof-919" covers-30="partial-function-application">
-      <description> Was hof-044: test that numeric promotion works for various kinds of functions. But there's
-      an error - the function item function($x as xs:float){$x+1} doesn't satisfy the required type
-      (function(xs:double) as xs:double) because it doesn't accept a double as an argument.
-      </description>
-      <created by="Michael Kay" on="2012-01-03"/>
-      <dependency type="spec" value="XQ30+"/>
-      <test>
-      declare function local:round($x as xs:double) as xs:double { fn:floor($x) }; 
-      declare function local:ops() as (function(xs:double) as xs:double)* 
-      	{ (abs#1, local:round#1, function($x as xs:float){$x+1}, round-half-to-even(?, 2)) }; 
-      string-join(for $f in local:ops() return string(round-half-to-even($f(xs:decimal('123.456')), 4)), '~')
       </test>
       <result>
          <error code="XPTY0004"/>

--- a/misc/HigherOrderFunctions.xml
+++ b/misc/HigherOrderFunctions.xml
@@ -603,12 +603,11 @@
       <description> numeric promotion works for various kinds of functions  </description>
       <created by="Michael Kay" on="2009-03-01"/>
       <modified by="Michael Kay" on="2011-01-03" change="see bug #15402"/>
-      <modified by="Gunther Rademacher" on="2024-03-11" change="reverted previous change as no longer necessary with XQ40+"/>
-      <dependency type="spec" value="XQ40+"/>
+      <dependency type="spec" value="XQ30+"/>
       <test>
       declare function local:round($x as xs:double) as xs:double { fn:floor($x) }; 
       declare function local:ops() as (function(xs:double) as xs:double)* 
-      	{ (abs#1, local:round#1, function($x as xs:float){$x+1}, round-half-to-even(?, 2)) }; 
+      	{ (abs#1, local:round#1, function($x as xs:double){$x+1}, round-half-to-even(?, 2)) }; 
       string-join(for $f in local:ops() return string(round-half-to-even($f(xs:decimal('123.456')), 4)), '~')
       </test>
       <result>
@@ -998,6 +997,40 @@
       </test>
       <result>
          <error code="XPTY0004"/>
+      </result>
+   </test-case>
+   
+   <test-case name="hof-919" covers-30="partial-function-application">
+      <description> Was hof-044: test that numeric promotion works for various kinds of functions. But there's
+      an error - the function item function($x as xs:float){$x+1} doesn't satisfy the required type
+      (function(xs:double) as xs:double) because it doesn't accept a double as an argument.
+      </description>
+      <created by="Michael Kay" on="2012-01-03"/>
+      <dependency type="spec" value="XQ30 XQ31"/>
+      <test>
+      declare function local:round($x as xs:double) as xs:double { fn:floor($x) }; 
+      declare function local:ops() as (function(xs:double) as xs:double)* 
+      	{ (abs#1, local:round#1, function($x as xs:float){$x+1}, round-half-to-even(?, 2)) }; 
+      string-join(for $f in local:ops() return string(round-half-to-even($f(xs:decimal('123.456')), 4)), '~')
+      </test>
+      <result>
+         <error code="XPTY0004"/>
+      </result>
+   </test-case>
+
+   <test-case name="hof-919a" covers-30="partial-function-application">
+      <description> Same as hof-919, but expecting a result for XQ40+ rather than a coercion error as with XQ3x 
+      </description>
+      <created by="Gunther Rademacher" on="2024-03-12"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+      declare function local:round($x as xs:double) as xs:double { fn:floor($x) }; 
+      declare function local:ops() as (function(xs:double) as xs:double)* 
+      	{ (abs#1, local:round#1, function($x as xs:float){$x+1}, round-half-to-even(?, 2)) }; 
+      string-join(for $f in local:ops() return string(round-half-to-even($f(xs:decimal('123.456')), 4)), '~')
+      </test>
+      <result>
+         <assert-string-value>123.456~123~124.456~123.46</assert-string-value>
       </result>
    </test-case>
 


### PR DESCRIPTION
Test case `hof-919` asks for a `XPTY0004` error, because a function expecting an `xs:float` argument did not accept `xs:double`. This was not permitted when the test case was created, but it is valid per the [new coercion rules](https://qt4cg.org/specifications/xquery-40/xquery-40-diff.html#id-coercion-rules).

Apparently the test case was created from `hof-044`, which was then modified to the function expecting `xs:double`. I propose to revert that change and mark test case `hof-044` with a dependency of `XQ40+`.