### PR TITLE
Fix incorrectly escaped characters

### DIFF
--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -635,7 +635,7 @@
                            'path-segments': ('','path'),
                            "query-parameters": map {
                              "a": ("1", "3"),
-                             "b": "2&amp;4"
+                             "b": "2&4"
                            }}]]>)</test>
     <result><assert-eq>`http://example.com/path?a=1&amp;a=3&amp;b=2%264`</assert-eq></result>
   </test-case>
@@ -647,12 +647,12 @@
                            "hierarchical": true(),
                            'authority': 'example.com',
                            'host': 'example.com',
-                           'path-segments': ('',' !"#$%&amp;''()*+,-./0123456789:;&lt;=>?'),
+                           'path-segments': ('',' !"#$%&''()*+,-./0123456789:;<=>?'),
                            "query-parameters": map {
-                             "a": (" !""#$%&amp;'()*+,-"),
-                             "b": ("./0123456789:;&lt;=>?")
+                             "a": (" !""#$%&'()*+,-"),
+                             "b": ("./0123456789:;<=>?")
                            },
-                           "fragment": " !""#$%&amp;'()*+,-./0123456789:;&lt;=>?"
+                           "fragment": " !""#$%&'()*+,-./0123456789:;<=>?"
                          }]]>)</test>
     <result>
       <assert-eq>`http://example.com/%20!%22%23$%25&amp;'()*+,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*+,-&amp;b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&amp;'()*+,-./0123456789:;%3C=%3E?`</assert-eq>


### PR DESCRIPTION
I'm working my way through https://github.com/qt4cg/qtspecs/issues/566 ...

I tried running them and I noticed two failures. I believe that these are errors introduced into the tests when I attempted improve support for escaped markup characters in XQuery. Because I wrapped `&amp;` inside a `CDATA` marked section, I ended up with `&` (and `<`) doubly-escaped. I don't think that was the intent. This PR fixes that.