### PR TITLE
Another attempt to fix escaping issues in the test

### DIFF
--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -628,32 +628,32 @@
   <test-case name="fn-build-uri-009">
     <description>Tests that a list of query parameter values is handled correctly.</description>
     <created by="Norm Tovey-Walsh" on="2023-10-24"/>
-    <test>fn:build-uri(<![CDATA[map {'scheme': 'http',
+    <test>fn:build-uri(map {'scheme': 'http',
                            "hierarchical": true(),
                            'authority': 'example.com',
                            'host': 'example.com',
                            'path-segments': ('','path'),
                            "query-parameters": map {
                              "a": ("1", "3"),
-                             "b": "2&amp;4"
-                           }}]]>)</test>
+                             "b": `2&amp;4`
+                           }})</test>
     <result><assert-eq>`http://example.com/path?a=1&amp;a=3&amp;b=2%264`</assert-eq></result>
   </test-case>
 
   <test-case name="fn-build-uri-010a">
     <description>Tests character encoding</description>
     <created by="Norm Tovey-Walsh" on="2023-10-26"/>
-    <test>fn:build-uri(<![CDATA[map {'scheme': 'http',
+    <test>fn:build-uri(map {'scheme': 'http',
                            "hierarchical": true(),
                            'authority': 'example.com',
                            'host': 'example.com',
-                           'path-segments': ('',' !"#$%&amp;''()*+,-./0123456789:;&lt;=>?'),
+                           'path-segments': ('',` !"#$%&amp;'()*+,-./0123456789:;&lt;=>?`),
                            "query-parameters": map {
-                             "a": (" !""#$%&amp;'()*+,-"),
-                             "b": ("./0123456789:;&lt;=>?")
+                             "a": (` !"#$%&amp;'()*+,-`),
+                             "b": (`./0123456789:;&lt;=>?`)
                            },
-                           "fragment": " !""#$%&amp;'()*+,-./0123456789:;&lt;=>?"
-                         }]]>)</test>
+                           "fragment": ` !"#$%&amp;'()*+,-./0123456789:;&lt;=>?`
+                         })</test>
     <result>
       <assert-eq>`http://example.com/%20!%22%23$%25&amp;'()*+,-.%2F0123456789:;%3C=%3E%3F?a=%20!%22%23$%25%26'()*+,-&amp;b=./0123456789:;%3C%3D%3E?#%20!%22%23$%25&amp;'()*+,-./0123456789:;%3C=%3E?`</assert-eq>
     </result>


### PR DESCRIPTION
I'm still working my way through https://github.com/qt4cg/qtspecs/issues/566 ...

This PR is attempting to fix the same errors that I described in #94 but uses the backtick string interpolation feature to make a string that (I believe) works the same in both XQuery and XPath.