### PR TITLE
Fix expeced results of fn-parse-uri-011c

### DIFF
--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -229,11 +229,9 @@ map {
   "uri": "//uncname/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
-  "authority": "uncname",
-  "host": "uncname",
-  "path": "/path/to/file",
+  "path": "//uncname/path/to/file",
   "filepath": "//uncname/path/to/file",
-  "path-segments": ("", "path", "to", "file")
+  "path-segments": ("", "", "uncname", "path", "to", "file")
 }</assert-deep-eq>
     </result>
   </test-case>


### PR DESCRIPTION
Based on the results that @ChristianGruen provided and upon closer inspection of the specification, I think these results are correct.

I think it's an open question whether they are the results we want, but they are correct with respect to what the specification currently says.