### PR TITLE
103 while-do-error-004: Reference wrongly typed variable

### DIFF
--- a/fn/while-do.xml
+++ b/fn/while-do.xml
@@ -319,9 +319,9 @@ head(while-do(
     <created by="Christian Gruen" on="2023-11-18"/>
     <test><![CDATA[
 head(while-do(
-  (1, 2),
-  fn($x, $p) { $p < 2 },
-  fn($s, $p as xs:string) { $s[2], $s[1] }
+  (),
+  empty#1,
+  fn($s, $p as xs:integer) { $p }
 ))]]></test>
     <result>
       <error code="XPTY0004"/>


### PR DESCRIPTION
Closes #103