### PR TITLE
Adapt enum test cases to current state of the specification

### DIFF
--- a/prod/EnumerationType.xml
+++ b/prod/EnumerationType.xml
@@ -7,7 +7,17 @@
    <test-case name="enum-001">
       <description>instance of enum()</description>
       <created by="Michael Kay" on="2020-12-01"/>
+      <modified by="Gunther Rademacher" on="2024-03-25" change="changed result from true to false"/>
       <test>"c" instance of enum("a", "b", "c", "d")</test>
+      <result>
+        <assert-false/>
+      </result>
+   </test-case> 
+   
+   <test-case name="enum-001a">
+      <description>castable as enum()</description>
+      <created by="Gunther Rademacher" on="2024-03-25"/>
+      <test>"c" castable as enum("a", "b", "c", "d")</test>
       <result>
         <assert-true/>
       </result>
@@ -21,13 +31,23 @@
          <assert-false/>
       </result>
    </test-case> 
+
+   <test-case name="enum-002a">
+      <description>castable as enum()</description>
+      <created by="Gunther Rademacher" on="2024-03-25"/>
+      <test>"g" castable as enum("a", "b", "c", "d")</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case> 
    
    <test-case name="enum-003">
       <description>cast as enum()</description>
       <created by="Michael Kay" on="2020-12-01"/>
+      <modified by="Gunther Rademacher" on="2024-03-25" change="changed result from XPST0003 to &quot;a&quot;"/>
       <test>"a" cast as enum("a", "b", "c", "d")</test>
       <result>
-         <error code="XPST0003"/>
+         <assert-eq>"a"</assert-eq>
       </result>
    </test-case> 
    
@@ -43,7 +63,17 @@
    <test-case name="enum-005">
       <description>singleton enum()</description>
       <created by="Michael Kay" on="2020-12-01"/>
+      <modified by="Gunther Rademacher" on="2024-03-25" change="changed result from true to false"/>
       <test>"a" instance of enum("a")</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case> 
+
+   <test-case name="enum-005a">
+      <description>singleton enum()</description>
+      <created by="Gunther Rademacher" on="2024-03-25"/>
+      <test>"a" castable as enum("a")</test>
       <result>
          <assert-true/>
       </result>
@@ -57,11 +87,30 @@
          <assert-false/>
       </result>
    </test-case> 
+
+   <test-case name="enum-006a">
+      <description>singleton enum()</description>
+      <created by="Michael Kay" on="2020-12-01"/>
+      <test>"z" castable as enum("a")</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case> 
    
    <test-case name="enum-007">
       <description>Union with enum</description>
       <created by="Michael Kay" on="2020-12-01"/>
+      <modified by="Gunther Rademacher" on="2024-03-25" change="changed result from true to false"/>
       <test>"z" instance of union(enum("a"), enum("z"))</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case> 
+
+   <test-case name="enum-007a">
+      <description>Union with enum</description>
+      <created by="Gunther Rademacher" on="2024-03-25"/>
+      <test>"z" castable as union(enum("a"), enum("z"))</test>
       <result>
          <assert-true/>
       </result>
@@ -70,16 +119,35 @@
    <test-case name="enum-008">
       <description>Substitutability enum</description>
       <created by="Michael Kay" on="2020-12-01"/>
+      <modified by="Gunther Rademacher" on="2024-03-25" change="changed result from true to false"/>
       <test>xs:NCName("a1234") instance of enum("x", "a1234")</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case> 
+   
+   <test-case name="enum-008a">
+      <description>Substitutability enum</description>
+      <created by="Gunther Rademacher" on="2024-03-25"/>
+      <test>xs:NCName("a1234") castable as enum("x", "a1234")</test>
       <result>
          <assert-true/>
       </result>
    </test-case> 
-   
+
    <test-case name="enum-009">
       <description>Case-sensitive</description>
       <created by="Michael Kay" on="2020-12-01"/>
       <test>xs:NCName("A1234") instance of enum("x", "a1234")</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case> 
+
+   <test-case name="enum-009a">
+      <description>Case-sensitive</description>
+      <created by="Gunther Rademacher" on="2024-03-25"/>
+      <test>xs:NCName("A1234") castable as enum("x", "a1234")</test>
       <result>
          <assert-false/>
       </result>

--- a/prod/EnumerationType.xml
+++ b/prod/EnumerationType.xml
@@ -197,6 +197,24 @@
          <assert-false/>
       </result>
    </test-case>
+
+   <test-case name="enum-015">
+      <description>instance of enum()</description>
+      <created by="Gunther Rademacher" on="2026-03-26"/>
+      <test>("A" cast as enum("A", "B")) instance of enum("A", "B")</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="enum-016">
+      <description>instance of enum()</description>
+      <created by="Gunther Rademacher" on="2026-03-26"/>
+      <test>("A" cast as enum("A", "B")) instance of enum("A", "C")</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
    
  
    


### PR DESCRIPTION
The test cases in `prod/EnumerationType.xml` expect that

- an `xs:string` literal is acceptable as an `instance of` an `enum` type,
- an `enum` type is not accepted on the right hand side of a `cast as` operator.

Either of this is not in line with the current specification. This change modifies the tests accordingly, adding additional `castable as` test cases to the `instance of` ones.