### PR TITLE
PR1123 Adaptive output changes for 4.0

### DIFF
--- a/ser/method-adaptive.xml
+++ b/ser/method-adaptive.xml
@@ -25,7 +25,7 @@
       <description>Test the adaptive serialization output method - empty map</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Spec change; and anchor the assertion regex"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -37,6 +37,24 @@
         <serialization-matches>^map\{\}$</serialization-matches>
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-02a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - empty map</description>
+    <created by="Andrew Coleman" on="2015-02-11"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Spec change; and anchor the assertion regex"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ40+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        map { } 
+
+      ]]></test>
+    <result>
+      <serialization-matches>^\{\}$</serialization-matches>
+    </result>
+  </test-case>
 
    <test-case name="Serialization-adaptive-03" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - empty sequence</description>
@@ -346,7 +364,7 @@
       <description>Test the adaptive serialization output method - map with duplicate names</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -362,6 +380,28 @@
         </any-of>    
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-19a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - map with duplicate names</description>
+    <created by="Andrew Coleman" on="2015-02-11"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ31+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+  
+        map { "one" : 1, xs:QName("one") : 1 }  
+
+      ]]></test>
+    <result>
+      <any-of>
+        <serialization-matches>^\{"one":1,Q\{\}one:1\}</serialization-matches>
+        <serialization-matches>^\{Q\{\}one:1,"one":1\}</serialization-matches>
+      </any-of>    
+    </result>
+  </test-case>
 
    <test-case name="Serialization-adaptive-20" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - array with attribute node</description>
@@ -386,7 +426,7 @@
    <test-case name="Serialization-adaptive-21" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - map with attribute value</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -399,6 +439,25 @@
         <serialization-matches>^map\{"key":att-name="att-value"\}$</serialization-matches>
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-21a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - map with attribute value</description>
+    <created by="Andrew Coleman" on="2015-02-11"/>
+    <modified by="Michael Kay" on="2024-03-27"/>
+    <dependency type="spec" value="XQ40+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+
+        map { "key": attribute att-name { "att-value" }}
+
+      ]]></test>
+    <result>
+      <serialization-matches>^\{"key":att-name="att-value"\}$</serialization-matches>
+    </result>
+  </test-case>
+  
 
    <test-case name="Serialization-adaptive-22" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - array with numeric INF</description>
@@ -423,7 +482,7 @@
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -436,6 +495,26 @@
         <serialization-matches>map\{"infinity":xs:float\("INF"\)\}</serialization-matches>
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-23a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - map with numeric INF</description>
+    <created by="Andrew Coleman" on="2015-02-11"/>
+    <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ31+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        
+        map { "infinity": xs:float("INF") }
+
+      ]]></test>
+    <result>
+      <serialization-matches>^\{"infinity":xs:float\("INF"\)\}</serialization-matches>
+    </result>
+  </test-case>
 
    <test-case name="Serialization-adaptive-24" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - array with NaN</description>
@@ -461,7 +540,7 @@
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -474,6 +553,26 @@
         <serialization-matches>^map\{"not-a-number":NaN\}$</serialization-matches>
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-25a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - map with NaN value</description>
+    <created by="Andrew Coleman" on="2015-02-11"/>
+    <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ40+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        
+        map { "not-a-number": xs:double("NaN") }
+
+      ]]></test>
+    <result>
+      <serialization-matches>^\{"not-a-number":NaN\}$</serialization-matches>
+    </result>
+  </test-case>
 
    <test-case name="Serialization-adaptive-26" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - array of functions</description>
@@ -504,7 +603,7 @@
       <modified by="Michael Kay" on="2015-11-27" change="Add HOF dependency"/>
       <modified by="Debbie Lockett" on="2020-10-27" 
        change="Corrected expected results. Inclusion of XML declaration is implementation defined. See Saxon bug 4647"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <dependency type="feature" value="higherOrderFunctions"/>
      
       <test><![CDATA[
@@ -519,6 +618,31 @@
         <serialization-matches><![CDATA[^\[[(]?fn:exists#1[)]?,[(]?1[)]?,[(]?(<\?xml[^<]+>)?<element>content</element>[)]?,\(\),[(]?\(anonymous-function\)#1[)]?,[(]?map\{"infinity":INF[)]?\},[(]?"json-string"[)]?\]$]]></serialization-matches>
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-27a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - mixed array</description>
+    <created by="Andrew Coleman" on="2015-02-11"/>
+    <modified by="Christian Gruen" on="2015-02-19" change="query and regular expression fixed"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Michael Kay" on="2015-11-27" change="Add HOF dependency"/>
+    <modified by="Debbie Lockett" on="2020-10-27" 
+      change="Corrected expected results. Inclusion of XML declaration is implementation defined. See Saxon bug 4647"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ31+"/>
+    <dependency type="feature" value="higherOrderFunctions"/>
+    
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        
+        [fn:exists#1, 1, <element>content</element>, (), function($a) { $a }, map { "infinity":xs:double("INF") }, "json-string"]
+
+      ]]></test>
+    <result>
+      <serialization-matches><![CDATA[^\[[(]?fn:exists#1[)]?,[(]?1[)]?,[(]?(<\?xml[^<]+>)?<element>content</element>[)]?,\(\),[(]?\(anonymous-function\)#1[)]?,[(]?\{"infinity":INF[)]?\},[(]?"json-string"[)]?\]$]]></serialization-matches>
+    </result>
+  </test-case>
    
    <test-case name="Serialization-adaptive-28" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - empty sequence</description>
@@ -600,7 +724,7 @@
       <description>Test the adaptive serialization output method - escaping in map keys</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -616,13 +740,35 @@
         </any-of>  
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-32a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - escaping in map keys</description>
+    <created by="Michael Kay" on="2015-07-13"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ40+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        
+        map{ "O'Neil says ""no""": 1 }
+
+      ]]></test>
+    <result>
+      <any-of>
+        <serialization-matches><![CDATA[^\{"O'Neil says ""no""":1\}]]></serialization-matches>
+        <serialization-matches><![CDATA[^\{'O''Neil says "no"':1\}]]></serialization-matches>
+      </any-of>  
+    </result>
+  </test-case>
    
    <test-case name="Serialization-adaptive-33" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - escaping in map values</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
       <modified by="Christian Gruen" on="2015-09-29" change="Regex fixed"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -638,13 +784,36 @@
         </any-of>  
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-33a" covers="adaptive-serialization">
+    <description>Test the adaptive serialization output method - escaping in map values</description>
+    <created by="Michael Kay" on="2015-07-13"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Christian Gruen" on="2015-09-29" change="Regex fixed"/>
+    <modified by="Christian Gruen" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ40+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        
+        map{ 1:"O'Neil says ""no""" }
+
+      ]]></test>
+    <result>
+      <any-of>
+        <serialization-matches><![CDATA[^\{1:"O'Neil says ""no"""\}]]></serialization-matches>
+        <serialization-matches><![CDATA[^\{1:'O''Neil says "no"'\}]]></serialization-matches>
+      </any-of>  
+    </result>
+  </test-case>
    
    <test-case name="Serialization-adaptive-34" covers="adaptive-serialization">
       <description>No quotes and no escaping when a map value has length > 1</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
       <modified by="Benito van der Zander" on="2020-10-23" change="allow different quotes"/>
-      <dependency type="spec" value="XQ31+"/>
+      <dependency type="spec" value="XQ31"/>
       <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -663,6 +832,32 @@
         </any-of>
       </result>
    </test-case>
+  
+  <test-case name="Serialization-adaptive-34a" covers="adaptive-serialization">
+    <description>No quotes and no escaping when a map value has length > 1</description>
+    <created by="Michael Kay" on="2015-07-13"/>
+    <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
+    <modified by="Benito van der Zander" on="2020-10-23" change="allow different quotes"/>
+    <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
+    <dependency type="spec" value="XQ40+"/>
+    <test><![CDATA[
+ 
+     	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+        declare option output:method "adaptive";
+        declare option output:item-separator "~";
+        
+        map{ "a":("quotes ("")", "apos (')") }
+
+      ]]></test>
+    <result>
+      <any-of>
+        <serialization-matches><![CDATA[^\{"a":\("quotes \(""\)","apos \('\)"\)\}$]]></serialization-matches>
+        <serialization-matches><![CDATA[^\{"a":\('quotes \("\)','apos \(''\)'\)\}$]]></serialization-matches>
+        <serialization-matches><![CDATA[^\{"a":\("quotes \(""\)",'apos \(''\)'\)\}$]]></serialization-matches>
+        <serialization-matches><![CDATA[^\{"a":\('quotes \("\)',"apos \('\)"\)\}$]]></serialization-matches>
+      </any-of>
+    </result>
+  </test-case>
 
   <test-case name="Serialization-adaptive-35" covers="adaptive-serialization">
       <description>Test the adaptive serialization output method - xs:untypedAtomic</description>

--- a/ser/method-adaptive.xml
+++ b/ser/method-adaptive.xml
@@ -4,7 +4,7 @@
    <link type="spec" document="http://www.w3.org/TR/xquery-30/"
          idref="doc-xquery30-Serialization"/>
 
-  <test-case name="Serialization-adaptive-01" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-01" >
       <description>Test the adaptive serialization output method - empty array</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -21,7 +21,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-02" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-02" >
       <description>Test the adaptive serialization output method - empty map</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Spec change; and anchor the assertion regex"/>
@@ -38,7 +38,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-02a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-02a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - empty map</description>
     <created by="Andrew Coleman" on="2015-02-11"/>
     <modified by="Michael Kay" on="2015-07-18" change="Spec change; and anchor the assertion regex"/>
@@ -56,7 +56,7 @@
     </result>
   </test-case>
 
-   <test-case name="Serialization-adaptive-03" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-03" >
       <description>Test the adaptive serialization output method - empty sequence</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -73,7 +73,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-04" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-04" >
       <description>Test the adaptive serialization output method - atomic value</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -90,7 +90,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-05" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-05" >
       <description>Test the adaptive serialization output method - atomic value</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -107,7 +107,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-06" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-06" >
       <description>Test the adaptive serialization output method - document node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -127,7 +127,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-07" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-07" >
       <description>Test the adaptive serialization output method - element node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -147,7 +147,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-08" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-08" >
       <description>Test the adaptive serialization output method - text node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -167,7 +167,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-09" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-09" >
       <description>Test the adaptive serialization output method - comment node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Anchor the assertion regex"/>
@@ -187,7 +187,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-10" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-10" >
       <description>Test the adaptive serialization output method - processing-instruction node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="regular expression fixed"/>
@@ -208,7 +208,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-11" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-11" >
       <description>Test the adaptive serialization output method - attribute node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-06-15" change="Allow some variability in the result"/>
@@ -227,7 +227,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-12" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-12" >
       <description>Test the adaptive serialization output method - function</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -247,7 +247,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-13" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-13" >
       <description>Test the adaptive serialization output method - anon function</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="regular expression fixed"/>
@@ -268,7 +268,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-14" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-14" >
       <description>Test the adaptive serialization output method - default item separator</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="regular expression fixed"/>
@@ -286,7 +286,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-15" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-15" >
       <description>Test the adaptive serialization output method - item-separator</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <dependency type="spec" value="XQ31+"/>
@@ -304,7 +304,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-16" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-16" >
       <description>Test the adaptive serialization output method - array</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -322,7 +322,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-17" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-17" >
       <description>Test the adaptive serialization output method - array of sequence of length > 1</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="regular expression fixed"/>
@@ -341,7 +341,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-18" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-18" >
       <description>Test the adaptive serialization output method - array of sequence of length > 1</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -360,7 +360,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-19" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-19" >
       <description>Test the adaptive serialization output method - map with duplicate names</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -381,12 +381,12 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-19a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-19a" >
     <description>Test the adaptive serialization output method - map with duplicate names</description>
     <created by="Andrew Coleman" on="2015-02-11"/>
     <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
     <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
-    <dependency type="spec" value="XQ31+"/>
+    <dependency type="spec" value="XQ40+"/>
     <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -403,7 +403,7 @@
     </result>
   </test-case>
 
-   <test-case name="Serialization-adaptive-20" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-20" >
       <description>Test the adaptive serialization output method - array with attribute node</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -423,7 +423,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-21" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-21" >
       <description>Test the adaptive serialization output method - map with attribute value</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <dependency type="spec" value="XQ31"/>
@@ -440,7 +440,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-21a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-21a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - map with attribute value</description>
     <created by="Andrew Coleman" on="2015-02-11"/>
     <modified by="Michael Kay" on="2024-03-27"/>
@@ -459,7 +459,7 @@
   </test-case>
   
 
-   <test-case name="Serialization-adaptive-22" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-22" >
       <description>Test the adaptive serialization output method - array with numeric INF</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -477,7 +477,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-23" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-23" >
       <description>Test the adaptive serialization output method - map with numeric INF</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
@@ -496,13 +496,13 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-23a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-23a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - map with numeric INF</description>
     <created by="Andrew Coleman" on="2015-02-11"/>
     <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
     <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
     <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
-    <dependency type="spec" value="XQ31+"/>
+    <dependency type="spec" value="XQ40+"/>
     <test><![CDATA[
  
      	declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -516,7 +516,7 @@
     </result>
   </test-case>
 
-   <test-case name="Serialization-adaptive-24" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-24" >
       <description>Test the adaptive serialization output method - array with NaN</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
@@ -535,7 +535,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-25" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-25" >
       <description>Test the adaptive serialization output method - map with NaN value</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
@@ -554,7 +554,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-25a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-25a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - map with NaN value</description>
     <created by="Andrew Coleman" on="2015-02-11"/>
     <modified by="Christian Gruen" on="2012-02-19" change="query fixed"/>
@@ -574,7 +574,7 @@
     </result>
   </test-case>
 
-   <test-case name="Serialization-adaptive-26" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-26" >
       <description>Test the adaptive serialization output method - array of functions</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2012-02-19" change="regular expression fixed"/>
@@ -595,7 +595,7 @@
       </result>
    </test-case>
 
-   <test-case name="Serialization-adaptive-27" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-27" >
       <description>Test the adaptive serialization output method - mixed array</description>
       <created by="Andrew Coleman" on="2015-02-11"/>
       <modified by="Christian Gruen" on="2015-02-19" change="query and regular expression fixed"/>
@@ -619,7 +619,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-27a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-27a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - mixed array</description>
     <created by="Andrew Coleman" on="2015-02-11"/>
     <modified by="Christian Gruen" on="2015-02-19" change="query and regular expression fixed"/>
@@ -628,7 +628,7 @@
     <modified by="Debbie Lockett" on="2020-10-27" 
       change="Corrected expected results. Inclusion of XML declaration is implementation defined. See Saxon bug 4647"/>
     <modified by="Michael Kay" on="2024-03-27" change="Spec change for 4.0"/>
-    <dependency type="spec" value="XQ31+"/>
+    <dependency type="spec" value="XQ40+"/>
     <dependency type="feature" value="higherOrderFunctions"/>
     
     <test><![CDATA[
@@ -644,7 +644,7 @@
     </result>
   </test-case>
    
-   <test-case name="Serialization-adaptive-28" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-28" >
       <description>Test the adaptive serialization output method - empty sequence</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -661,7 +661,7 @@
       </result>
    </test-case>
    
-   <test-case name="Serialization-adaptive-29" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-29" >
       <description>Test the adaptive serialization output method - sequence with item-separator</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -679,7 +679,7 @@
       </result>
    </test-case>
    
-   <test-case name="Serialization-adaptive-30" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-30" >
       <description>Test the adaptive serialization output method - sequence with item-separator</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -698,7 +698,7 @@
       </result>
    </test-case>
    
-   <test-case name="Serialization-adaptive-31" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-31" >
       <description>Test the adaptive serialization output method - map with duplicate keys</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -720,7 +720,7 @@
       </result>
    </test-case>
    
-   <test-case name="Serialization-adaptive-32" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-32" >
       <description>Test the adaptive serialization output method - escaping in map keys</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -741,7 +741,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-32a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-32a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - escaping in map keys</description>
     <created by="Michael Kay" on="2015-07-13"/>
     <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -763,7 +763,7 @@
     </result>
   </test-case>
    
-   <test-case name="Serialization-adaptive-33" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-33" >
       <description>Test the adaptive serialization output method - escaping in map values</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -785,7 +785,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-33a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-33a" covers-40="PR1123">
     <description>Test the adaptive serialization output method - escaping in map values</description>
     <created by="Michael Kay" on="2015-07-13"/>
     <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -808,7 +808,7 @@
     </result>
   </test-case>
    
-   <test-case name="Serialization-adaptive-34" covers="adaptive-serialization">
+   <test-case name="Serialization-adaptive-34" >
       <description>No quotes and no escaping when a map value has length > 1</description>
       <created by="Michael Kay" on="2015-07-13"/>
       <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -833,7 +833,7 @@
       </result>
    </test-case>
   
-  <test-case name="Serialization-adaptive-34a" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-34a" covers-40="PR1123">
     <description>No quotes and no escaping when a map value has length > 1</description>
     <created by="Michael Kay" on="2015-07-13"/>
     <modified by="Michael Kay" on="2015-07-18" change="Implement spec change"/>
@@ -859,7 +859,7 @@
     </result>
   </test-case>
 
-  <test-case name="Serialization-adaptive-35" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-35" >
       <description>Test the adaptive serialization output method - xs:untypedAtomic</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -873,7 +873,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-36" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-36" >
       <description>Test the adaptive serialization output method - xs:dateTime</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -887,7 +887,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-37" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-37" >
       <description>Test the adaptive serialization output method - xs:dateTimeStamp</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <modified by="Tim Mills" on="2016-10-05" change="See Bug 29913"/>
@@ -903,7 +903,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-38" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-38" >
       <description>Test the adaptive serialization output method - xs:date</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -917,7 +917,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-39" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-39" >
       <description>Test the adaptive serialization output method - xs:time</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -931,7 +931,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-40" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-40" >
       <description>Test the adaptive serialization output method - xs:duration</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -945,7 +945,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-41" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-41" >
       <description>Test the adaptive serialization output method - xs:yearMonthDuration</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <modified by="Tim Mills" on="2016-10-05" change="See Bug 29913"/>
@@ -960,7 +960,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-42" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-42" >
       <description>Test the adaptive serialization output method - xs:dayTimeDuration</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <modified by="Tim Mills" on="2016-10-05" change="See Bug 29913"/>
@@ -975,7 +975,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-43" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-43" >
       <description>Test the adaptive serialization output method - xs:float</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -989,7 +989,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-44" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-44" >
       <description>Test the adaptive serialization output method - xs:double</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1003,7 +1003,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-45" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-45" >
       <description>Test the adaptive serialization output method - xs:decimal</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1017,7 +1017,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-46" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-46" >
       <description>Test the adaptive serialization output method - xs:integer</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1031,7 +1031,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-47" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-47" >
       <description>Test the adaptive serialization output method - xs:nonPositiveInteger</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1045,7 +1045,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-48" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-48" >
       <description>Test the adaptive serialization output method - xs:negativeInteger</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1059,7 +1059,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-49" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-49" >
       <description>Test the adaptive serialization output method - xs:long</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1073,7 +1073,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-50" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-50" >
       <description>Test the adaptive serialization output method - xs:int</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1087,7 +1087,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-51" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-51" >
       <description>Test the adaptive serialization output method - xs:short</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1101,7 +1101,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-52" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-52" >
       <description>Test the adaptive serialization output method - xs:byte</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1115,7 +1115,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-53" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-53" >
       <description>Test the adaptive serialization output method - xs:nonNegativeInteger</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1129,7 +1129,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-54" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-54" >
       <description>Test the adaptive serialization output method - xs:unsignedLong</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1143,7 +1143,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-55" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-55" >
       <description>Test the adaptive serialization output method - xs:unsignedInt</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1157,7 +1157,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-56" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-56" >
       <description>Test the adaptive serialization output method - xs:unsignedShort</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1171,7 +1171,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-57" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-57" >
       <description>Test the adaptive serialization output method - xs:unsignedByte</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1185,7 +1185,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-58" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-58" >
       <description>Test the adaptive serialization output method - xs:positiveInteger</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1199,7 +1199,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-59" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-59" >
       <description>Test the adaptive serialization output method - xs:gYearMonth</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1214,7 +1214,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-60" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-60" >
       <description>Test the adaptive serialization output method - xs:gYear</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1229,7 +1229,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-61" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-61" >
       <description>Test the adaptive serialization output method - xs:gMonthDay</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1244,7 +1244,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-62" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-62" >
       <description>Test the adaptive serialization output method - xs:gDay</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1259,7 +1259,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-63" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-63" >
       <description>Test the adaptive serialization output method - xs:gMonth</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1274,7 +1274,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-64" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-64" >
       <description>Test the adaptive serialization output method - xs:string</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1291,7 +1291,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-65" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-65" >
       <description>Test the adaptive serialization output method - xs:normalizedString</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1309,7 +1309,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-66" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-66" >
       <description>Test the adaptive serialization output method - xs:token</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1327,7 +1327,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-67" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-67" >
       <description>Test the adaptive serialization output method - xs:language</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1345,7 +1345,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-68" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-68" >
       <description>Test the adaptive serialization output method - xs:NMTOKEN</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1363,7 +1363,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-69" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-69" >
       <description>Test the adaptive serialization output method - xs:Name</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1380,7 +1380,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-70" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-70" >
       <description>Test the adaptive serialization output method - xs:NCName</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1398,7 +1398,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-71" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-71" >
       <description>Test the adaptive serialization output method - xs:ID</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1416,7 +1416,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-72" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-72" >
       <description>Test the adaptive serialization output method - xs:IDREF</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1433,7 +1433,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-73" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-73" >
       <description>Test the adaptive serialization output method - xs:ENTITY</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1450,7 +1450,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-74" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-74" >
       <description>Test the adaptive serialization output method - xs:boolean</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1465,7 +1465,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-75" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-75" >
       <description>Test the adaptive serialization output method - xs:base64Binary</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1479,7 +1479,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-76" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-76" >
       <description>Test the adaptive serialization output method - xs:hexBinary</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1494,7 +1494,7 @@
    </test-case>
 
 
-  <test-case name="Serialization-adaptive-77" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-77" >
       <description>Test the adaptive serialization output method - xs:anyURI</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <modified by="Michael Kay" on="2016-10-07" change="respond to spec change"/>
@@ -1509,7 +1509,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-78" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-78" >
       <description>Test the adaptive serialization output method - xs:QName</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1523,7 +1523,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-79" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-79" >
       <description>Test the adaptive serialization output method - xs:string escaping</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1540,7 +1540,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-80" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-80" >
       <description>Test the adaptive serialization output method - xs:string escaping</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1557,7 +1557,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-81" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-81" >
       <description>Test the adaptive serialization output method - xs:untypedAtomic escaping</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1574,7 +1574,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-82" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-82" >
       <description>Test the adaptive serialization output method - xs:untypedAtomic escaping</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1591,7 +1591,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-83" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-83" >
       <description>Test the adaptive serialization output method - xs:anyURI escaping</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <dependency type="spec" value="XQ31+"/>
@@ -1608,7 +1608,7 @@
       </result>
    </test-case>
 
-  <test-case name="Serialization-adaptive-84" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-84" >
       <description>Test the adaptive serialization output method - xs:anyURI escaping</description>
       <created by="Tim Mills" on="2016-09-13"/>
       <modified by="Josh Spiegel" on="2016-10-10" change="Bug 29926"/>
@@ -1627,7 +1627,7 @@
       </result>
    </test-case>
 
-<test-case name="Serialization-adaptive-85" covers="adaptive-serialization">
+<test-case name="Serialization-adaptive-85" >
     <description>Test the adaptive serialization output method - xs:string escaping (Saxon bug 5387)</description>
     <created by="Michael Kay" on="2022-03-12"/>
     <dependency type="spec" value="XQ31+"/>
@@ -1644,7 +1644,7 @@
     </result>
   </test-case>
   
-  <test-case name="Serialization-adaptive-86" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-86" >
     <description>Test the adaptive serialization output method - xs:string escaping (Saxon bug 5387)</description>
     <created by="Michael Kay" on="2022-03-12"/>
     <dependency type="spec" value="XQ31+"/>
@@ -1661,7 +1661,7 @@
     </result>
   </test-case>
   
-  <test-case name="Serialization-adaptive-87" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-87" >
     <description>Test the adaptive serialization output method - xs:string escaping (Saxon bug 5387)</description>
     <created by="Michael Kay" on="2022-03-12"/>
     <dependency type="spec" value="XQ31+"/>
@@ -1678,7 +1678,7 @@
     </result>
   </test-case>
   
-  <test-case name="Serialization-adaptive-88" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-88" >
     <description>Test the adaptive serialization output method - attribute node -escaping - Saxon bug 5603</description>
     <created by="Michael Kay" on="2022-07-13"/>
     <dependency type="spec" value="XQ31+"/>
@@ -1695,7 +1695,7 @@
     </result>
   </test-case>
   
-  <test-case name="Serialization-adaptive-89" covers="adaptive-serialization">
+  <test-case name="Serialization-adaptive-89" >
     <description>Test the adaptive serialization output method - text node - escaping - Saxon bug 5604</description>
     <created by="Michael Kay" on="2022-07-13"/>
     <dependency type="spec" value="XQ31+"/>


### PR DESCRIPTION
The spec PR changes the adaptive output from `map{}` to `{}`.