### PR TITLE
PR1182 predicates returning empty sequence

### DIFF
--- a/array/filter.xml
+++ b/array/filter.xml
@@ -196,8 +196,21 @@
         </result>
     </test-case>
     
+    <test-case name="array-filter-404" covers-40="PR1128">
+        <description>Callback returns ()</description>
+        <created by="Michael Kay" on="2024-05-05"/>
+        <environment ref="array"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
+        <test>array:filter(array{1 to 10}, fn{if (. mod 2) {true()}})</test>
+        <result>
+            <assert-deep-eq>array{1, 3, 5, 7, 9}</assert-deep-eq>
+        </result>
+    </test-case>
     
     
+    
+    
+    PR1128
     
  
 </test-set>

--- a/array/filter.xml
+++ b/array/filter.xml
@@ -207,10 +207,4 @@
         </result>
     </test-case>
     
-    
-    
-    
-    PR1128
-    
- 
 </test-set>

--- a/array/index-where.xml
+++ b/array/index-where.xml
@@ -191,10 +191,19 @@
   
   <test-case name="array-index-where-110" covers-40="PR828">
     <description>Positional callback function</description>
-    <created by="Micahel Kay" on="2024-03-14"/>
+    <created by="Michael Kay" on="2024-03-14"/>
     <test><![CDATA[array:index-where(array{1 to 10}, fn($val, $pos){$pos gt 6})]]></test>
     <result>
       <assert-deep-eq>7, 8, 9, 10</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="array-index-where-111" covers-40="PR1128">
+    <description>Callback function returns ()</description>
+    <created by="Michael Kay" on="2024-05-05"/>
+    <test><![CDATA[array:index-where([13, 5, (), 2, 20], fn($val, $pos){$val gt 6})]]></test>
+    <result>
+      <assert-deep-eq>1, 5</assert-deep-eq>
     </result>
   </test-case>
   

--- a/fn/codepoints-to-string.xml
+++ b/fn/codepoints-to-string.xml
@@ -820,7 +820,7 @@
    <!-- Following test cases anticipated codepoints-to-string becoming sequence-variadic but this change has
       not been confirmed. MHK 2023-11-23 -->
    
-   <test-case name="K4-codepoints-to-string-90" covers-40="fn-codepoints-to-string">
+   <!--<test-case name="K4-codepoints-to-string-90" covers-40="fn-codepoints-to-string">
       <description>Function no longer becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2023-11-23"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -838,9 +838,9 @@
       <result>
          <error code="XPST0017"/>
       </result>
-   </test-case>
+   </test-case>-->
 
-   <!--<test-case name="K4-codepoints-to-string-01" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-01" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -850,7 +850,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-02" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-02" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -860,7 +860,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-03" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-03" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -870,7 +870,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-04" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-04" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -880,7 +880,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-05" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-05" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -890,7 +890,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-06" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-06" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -900,7 +900,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-07" covers-40="fn-codepoints-to-string">
+   <test-case name="K4-codepoints-to-string-07" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -908,5 +908,65 @@
       <result>
          <assert-eq>"abc"</assert-eq>
       </result>
-   </test-case>-->
+   </test-case>
+   
+   <test-case name="K4-codepoints-to-string-08" covers-40="PR1137">
+      <description>Function becomes variadic in 4.0</description>
+      <created by="Michael Kay" on="2010-12-15"/>
+      <dependency type="spec" value="XP40+ XQ40+"></dependency>
+      <test>codepoints-to-string(values:=(97,98,99))</test>
+      <result>
+         <assert-eq>"abc"</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="K4-codepoints-to-string-09" covers-40="PR1137">
+      <description>Function becomes variadic in 4.0</description>
+      <created by="Michael Kay" on="2010-12-15"/>
+      <dependency type="spec" value="XP40+ XQ40+"></dependency>
+      <test>codepoints-to-string(values:=97, values:=(98,99))</test>
+      <result>
+         <error code="TBA"/>
+      </result>
+   </test-case>
+   
+   <test-case name="K4-codepoints-to-string-09" covers-40="PR1137">
+      <description>Function becomes variadic in 4.0</description>
+      <created by="Michael Kay" on="2010-12-15"/>
+      <dependency type="spec" value="XP40+ XQ40+"></dependency>
+      <test>codepoints-to-string(97, values:=(98,99))</test>
+      <result>
+         <error code="TBA"/>
+      </result>
+   </test-case>
+   
+   <test-case name="K4-codepoints-to-string-10" covers-40="PR1137">
+      <description>Function becomes variadic in 4.0</description>
+      <created by="Michael Kay" on="2010-12-15"/>
+      <dependency type="spec" value="XP40+ XQ40+"></dependency>
+      <test>codepoints-to-string#3(97, 98, 99)</test>
+      <result>
+         <assert-eq>"abc"</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="K4-codepoints-to-string-11" covers-40="PR1137">
+      <description>Function becomes variadic in 4.0</description>
+      <created by="Michael Kay" on="2010-12-15"/>
+      <dependency type="spec" value="XP40+ XQ40+"></dependency>
+      <test>codepoints-to-string#3(97, (98, 99))</test>
+      <result>
+         <error code="TBA"/>
+      </result>
+   </test-case>
+   
+   <test-case name="K4-codepoints-to-string-12" covers-40="PR1137">
+      <description>Function becomes variadic in 4.0</description>
+      <created by="Michael Kay" on="2010-12-15"/>
+      <dependency type="spec" value="XP40+ XQ40+"></dependency>
+      <test>codepoints-to-string#3(97, ?, 99)(98)</test>
+      <result>
+         <assert-eq>"abc"</assert-eq>
+      </result>
+   </test-case>
 </test-set>

--- a/fn/codepoints-to-string.xml
+++ b/fn/codepoints-to-string.xml
@@ -930,7 +930,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-09" covers-40="PR1137">
+   <test-case name="K4-codepoints-to-string-10" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -940,7 +940,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-10" covers-40="PR1137">
+   <test-case name="K4-codepoints-to-string-11" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -950,7 +950,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-11" covers-40="PR1137">
+   <test-case name="K4-codepoints-to-string-12" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>
@@ -960,7 +960,7 @@
       </result>
    </test-case>
    
-   <test-case name="K4-codepoints-to-string-12" covers-40="PR1137">
+   <test-case name="K4-codepoints-to-string-13" covers-40="PR1137">
       <description>Function becomes variadic in 4.0</description>
       <created by="Michael Kay" on="2010-12-15"/>
       <dependency type="spec" value="XP40+ XQ40+"></dependency>

--- a/fn/contains-subsequence.xml
+++ b/fn/contains-subsequence.xml
@@ -253,6 +253,15 @@
         </result>
     </test-case>
     
+    <test-case name="contains-subsequence-107" covers-40="PR1128">
+        <description>Predicate returns empty</description>
+        <created by="Michael Kay" on="2024-05-05"/>
+        <test>contains-subsequence((-4, -3, -5, -2, 1 to 9, -6, 20 to 30), 1 to 10, function($x, $y){()})</test>
+        <result>
+            <assert-false/>
+        </result>
+    </test-case>
+    
     
     <test-case name="contains-subsequence-901">
         <description>Comparison function throws error</description>

--- a/fn/deep-equal.xml
+++ b/fn/deep-equal.xml
@@ -2382,7 +2382,7 @@
       </result>
    </test-case>
 
-   <test-case name="K2-SeqDeepEqualFunc-20a" changes-40="TBA">
+   <test-case name="K2-SeqDeepEqualFunc-20a" covers-40="TBA">
       <description> One of the operands has two text nodes, and hence it evaluate to false. </description>
       <created by="Frans Englich" on="2007-11-26"/>
       <modified by="Christian Gruen" on="2024-03-07" change="text nodes are now merged in 4.0"/>

--- a/fn/deep-equal.xml
+++ b/fn/deep-equal.xml
@@ -5013,7 +5013,7 @@ return deep-equal(
       </result>
    </test-case>
    
-   <test-case name="deep-equal-40-items-equal-009" covers-40="PR1120">
+   <test-case name="deep-equal-40-items-equal-009" covers-40="PR1120 PR1150">
       <description>Compare unordered sequence with items-equal callback</description>
       <created by="Michael Kay" on="2024-04-22"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
@@ -5029,7 +5029,7 @@ return deep-equal(
       </result>
    </test-case>
    
-   <test-case name="deep-equal-40-items-equal-010" covers-40="PR1120">
+   <test-case name="deep-equal-40-items-equal-010" covers-40="PR1120 PR1150">
       <description>Compare unordered sequence with items-equal callback</description>
       <created by="Michael Kay" on="2024-04-22"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
@@ -5045,7 +5045,7 @@ return deep-equal(
       </result>
    </test-case>
    
-   <test-case name="deep-equal-40-items-equal-011" covers-40="PR1120">
+   <test-case name="deep-equal-40-items-equal-011" covers-40="PR1120 PR1150">
       <description>Compare unordered elements with items-equal callback</description>
       <created by="Michael Kay" on="2024-04-22"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
@@ -5067,7 +5067,7 @@ return deep-equal(
       </result>
    </test-case>
    
-   <test-case name="deep-equal-40-items-equal-012" covers-40="PR1120">
+   <test-case name="deep-equal-40-items-equal-012" covers-40="PR1120 PR1150">
       <description>Compare unordered elements with items-equal callback</description>
       <created by="Michael Kay" on="2024-04-22"/>
       <dependency type="spec" value="XP40+ XQ40+"/>

--- a/fn/do-until.xml
+++ b/fn/do-until.xml
@@ -260,5 +260,14 @@ head(do-until((1, 2), fn($s as xs:integer) { $s[2], 1 }, fn($x, $p) { $p = 1 }))
       <error code="XPTY0004"/>
     </result>
   </test-case>
+  
+  <test-case name="do-until-024" covers-40="PR1128">
+    <description>do-until, predicate returns ()</description>
+    <created by="Michael Kay" on="2024-05-05"/>
+    <test><![CDATA[do-until(1, fn($x) { $x, $x }, fn($x) { if (count($x) >= 3) {true()} })]]></test>
+    <result>
+      <assert-deep-eq>1, 1, 1, 1</assert-deep-eq>
+    </result>
+  </test-case>
 
 </test-set>

--- a/fn/ends-with-subsequence.xml
+++ b/fn/ends-with-subsequence.xml
@@ -262,6 +262,15 @@
         </result>
     </test-case>
     
+    <test-case name="ends-with-subsequence-107" covers-40="PR1128">
+        <description>Predicate can return ()</description>
+        <created by="Michael Kay" on="2024-05-05"/>
+        <test>ends-with-subsequence(-5000 to -1000, 1 to 10, function($x, $y){$x eq $y[22]})</test>
+        <result>
+            <assert-false/>
+        </result>
+    </test-case>
+    
     
     <test-case name="ends-with-subsequence-901">
         <description>Comparison function throws error</description>

--- a/fn/every.xml
+++ b/fn/every.xml
@@ -287,6 +287,16 @@
       </result>
    </test-case>
    
+   <test-case name="every-39" covers-40="PR1128">
+      <description>Predicate returns empty sequence</description>
+      <created by="Michael Kay" on="2024-05-05"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test><![CDATA[every(parse-xml('<doc><a id="1"/><b/><c/></doc>'), fn{@id eq '1'})]]></test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+   
    
    <test-case name="every-empty" covers-40="PR901">
       <description>Optional argument: empty sequence</description>

--- a/fn/filter.xml
+++ b/fn/filter.xml
@@ -115,14 +115,27 @@
                 <error code="XPTY0004"/>
         </result>
     </test-case>
+   
     <test-case name="filter-902">
         <description>filter function - returns empty sequence </description>
         <created by="Michael Kay" on="2010-02-10"/>
+       <dependency type="spec" value="XP30 XP31 XQ30 XQ31"/>
         <test>filter(("apple", "pear", "apricot", "advocado", "orange"), function($x){if(starts-with($x,'a')) then true() else ()})</test>
         <result>
                 <error code="XPTY0004"/>
         </result>
     </test-case>
+   
+   <test-case name="filter-902a" covers-40="PR1128">
+      <description>filter function - returns empty sequence </description>
+      <created by="Michael Kay" on="2024-05-05"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>filter(("apple", "pear", "apricot", "advocado", "orange"), function($x){if(starts-with($x,'a')) then true() else ()})</test>
+      <result>
+         <assert-deep-eq>"apple", "apricot", "advocado"</assert-deep-eq>
+      </result>
+   </test-case>
+   
     <test-case name="filter-903">
         <description>filter function - returns non-singleton sequence</description>
         <created by="Michael Kay" on="2010-02-10"/>
@@ -317,10 +330,20 @@
    <test-case name="fn-filter-015">
       <description>Evaluates the "filter" function with $f set to a function which _could_ (and does) return a non-boolean value </description>
       <created by="Tim Mills" on="2012-05-01"/>
-      <dependency type="spec" value="XP30+ XQ30+"/>
+      <dependency type="spec" value="XP30 XP31 XQ30 XQ31"/>
       <test>fn:filter( 1 to 10, function($arg) { if ($arg eq 10) then () else fn:true()})</test>
       <result>
          <error code="XPTY0004" />
+      </result>
+   </test-case>
+   
+   <test-case name="fn-filter-015a" covers-40="PR1128">
+      <description>Evaluates the "filter" function with $f set to a function which _could_ (and does) return a non-boolean value </description>
+      <created by="Michael Kay" on="2024-05-05"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:filter( 1 to 10, function($arg) { if ($arg eq 10) then () else fn:true()})</test>
+      <result>
+         <assert-deep-eq>1 to 9</assert-deep-eq>
       </result>
    </test-case>
 
@@ -498,6 +521,17 @@
          $it gt 12 and $pos instance of xs:long} )</test>
       <result>
          <assert-deep-eq>13 to 20</assert-deep-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="fn-filter-407" covers-40="PR1128">
+      <description>Supply a callback returning ()</description>
+      <created by="Michael Kay" on="2024-05-05"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:filter(10 to 20, fn($it as xs:integer, $pos as xs:long) as xs:boolean? {
+         (true(), true(), true())[$pos]} )</test>
+      <result>
+         <assert-deep-eq>10 to 12</assert-deep-eq>
       </result>
    </test-case>
    

--- a/fn/index-where.xml
+++ b/fn/index-where.xml
@@ -185,5 +185,14 @@
       <assert-empty/>
     </result>
   </test-case>
+  
+  <test-case name="index-where-110" covers-40="PR1128">
+    <description>Filter expression, returns empty sequence</description>
+    <created by="Michael Kay" on="2024-05-05"/>
+    <test><![CDATA[fn:index-where((0 to 5), fn($x){(true(), false(), true())[$x]})]]></test>
+    <result>
+      <assert-deep-eq>2, 4</assert-deep-eq>
+    </result>
+  </test-case>
 
 </test-set>

--- a/fn/load-xquery-module.xml
+++ b/fn/load-xquery-module.xml
@@ -1113,11 +1113,12 @@
     <description>Loads a module, ignoring unrecognised option in second argument.</description>
     <created by="Debbie Lockett" on="2015-06-04"/>
     <modified by="Debbie Lockett" on="2015-09-04" change="Use XPath syntax in test"/>
+    <modified by="Debbie Lockett" on="2024-04-26" change="4.0 encourages rejecting invalid options unless namespaced"/>
     <module uri="http://www.w3.org/fots/fn/load-xquery-module/valid/module" file="load-xquery-module/valid-module.xqm"/>    
     <test>
       let $module-ns := "http://www.w3.org/fots/fn/load-xquery-module/valid/module",
        $module-unrec := "http://www.w3.example/unrecognised/namespace/nobody/uses",
-       $module := fn:load-xquery-module($module-ns, map{"nonexistant-option" : "ignored"})
+       $module := fn:load-xquery-module($module-ns, map{QName("urn:somthing","nonexistant-option") : "ignored"})
       return
       ($module("variables")(QName($module-ns, "var1")), $module("variables")(QName($module-ns, "var2")), 
       $module("functions")(QName($module-ns, "func1"))(0)(), $module("functions")(QName($module-ns, "func2"))(0)())

--- a/fn/partition.xml
+++ b/fn/partition.xml
@@ -210,6 +210,15 @@
     </result>
   </test-case>
   
+  <test-case name="partition-024" covers-40="PR1128">
+    <description>Callback returns empty sequence</description>
+    <created by="Michael Kay" on="2024-05-05"/>
+    <test><![CDATA[partition(tokenize('In the beginning was the word'), function($a,$b,$pos) { {"the":true()}?$b })]]></test>
+    <result>
+      <assert-deep-eq>["In"],["the","beginning","was"],["the","word"]</assert-deep-eq>
+    </result>
+  </test-case>
+  
   <test-case name="partition-100">
     <description>Test equivalent expression given in spec</description>
     <created by="Michael Kay" on="2023-04-24"/>

--- a/fn/some.xml
+++ b/fn/some.xml
@@ -284,6 +284,26 @@
       </result>
    </test-case>
    
+   <test-case name="some-39" covers-40="PR1128">
+      <description>some#2, predicate returns ()</description>
+      <created by="Michael Kay" on="2024-05-05"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>some((2, 1, 0, 1), fn($val, $pos){ {0:true(), 1:false()}?$val})</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+   
+   <test-case name="some-40" covers-40="PR1128">
+      <description>some#2, predicate returns ()</description>
+      <created by="Michael Kay" on="2024-05-05"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>some((2, 3, 1), fn($val, $pos){ {0:true(), 1:false()}?$val})</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+   
  
    
    <test-case name="some-empty" covers-40="PR901">

--- a/fn/starts-with-subsequence.xml
+++ b/fn/starts-with-subsequence.xml
@@ -262,6 +262,15 @@
         </result>
     </test-case>
     
+    <test-case name="starts-with-subsequence-107" covers-40="PR1128">
+        <description>Predicate can return ()</description>
+        <created by="Michael Kay" on="2024-05-06"/>
+        <test>starts-with-subsequence(1 to 20, 1 to 10, function($x, $y){(true(), true())[$x]})</test>
+        <result>
+            <assert-false/>
+        </result>
+    </test-case>
+    
     <test-case name="starts-with-subsequence-901">
         <description>Comparison function throws error</description>
         <created by="Michael Kay" on="2022-10-27"/>

--- a/fn/subsequence-where.xml
+++ b/fn/subsequence-where.xml
@@ -834,6 +834,16 @@
         </result>
     </test-case>
     
+    <test-case name="subsequence-between-005" covers-40="PR1128">
+        <description>Return value () for start and end functions</description>
+        <created by="Michael Kay" on="2024-02-21"/>
+        <test>subsequence-where(1 to 29, from := fn($it,$pos){if($pos=3){true()}}, 
+                                         to   := fn($it,$pos){if($pos=8){true()}})</test>
+        <result>
+            <assert-deep-eq>3 to 8</assert-deep-eq>
+        </result>
+    </test-case>
+    
     
     
     

--- a/fn/take-while.xml
+++ b/fn/take-while.xml
@@ -126,6 +126,15 @@
         </result>
     </test-case>
     
+    <test-case name="take-while-014">
+        <description>Callback returns empty sequence</description>
+        <created by="Michael Kay" on="2024-05-05"/>
+        <test>take-while((1 to 10, 12 to 20), fn($it, $pos){if ($pos mod 2 eq $it mod 2) {true()}})</test>
+        <result>
+            <assert-deep-eq>1 to 10</assert-deep-eq>
+        </result>
+    </test-case>
+    
     <test-case name="take-while-901" covers-40="PR1046">
         <description>Test use of EBV is NOT allowed</description>
         <created by="Michael Kay" on="2024-02-28"/>

--- a/fn/while-do.xml
+++ b/fn/while-do.xml
@@ -271,6 +271,18 @@ return while-do(1, $pred, $action)]]></test>
       <assert-true/>
     </result>
   </test-case>
+  
+  <test-case name="while-do-025" covers-40="PR1128">
+    <description>Predicate returns ()</description>
+    <created by="Michael Kay" on="2024-05-05"/>
+    <test><![CDATA[
+      let $s := (1 to 1000)
+      return while-do(1, function($x) { $x eq $s[$x] }, function($x) { $x + 1 })
+    ]]></test>
+    <result>
+      <assert-eq>1001</assert-eq>
+    </result>
+  </test-case>
 
   <test-case name="while-do-error-001" covers-40="PR828">
     <description>Wrong predicate type</description>

--- a/map/filter.xml
+++ b/map/filter.xml
@@ -2,6 +2,7 @@
   <description>Tests for the map:filter function</description>
   <link type="spec" document="http://www.w3.org/TR/xpath-functions-30/" idref="func-map-filter"/>
   <dependency type="spec" value="XP40+ XQ40+"/>
+  
   <test-case name="map-filter-001">
     <description>Empty map with predicate accepting all results</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -10,6 +11,7 @@
       <assert-deep-eq>map{}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-002">
     <description>Empty map with predicate accepting no results</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -18,6 +20,7 @@
       <assert-deep-eq>map{}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-003">
     <description>Singleton map with predicate accepting all results</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -26,6 +29,7 @@
       <assert-deep-eq>map{1:2}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-004">
     <description>Singleton map with predicate accepting no results</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -34,6 +38,7 @@
       <assert-deep-eq>map{}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-005">
     <description>Singleton map with predicate checking key</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -42,6 +47,7 @@
       <assert-deep-eq>map{1:2}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-006">
     <description>Singleton map with predicate checking key</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -50,6 +56,7 @@
       <assert-deep-eq>map{}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-007">
     <description>Singleton map with predicate checking value</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -58,6 +65,7 @@
       <assert-deep-eq>map{}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-008">
     <description>Singleton map with predicate checking value</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -66,6 +74,7 @@
       <assert-deep-eq>map{1:2}</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-009">
     <description>Map with predicate checking key</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -74,6 +83,7 @@
       <assert-eq>1</assert-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-010">
     <description>Map with predicate checking value</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -82,6 +92,7 @@
       <assert-deep-eq>'1', '10'</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-011">
     <description>Map with built-in predicate function</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -90,6 +101,7 @@
       <assert-string-value>a</assert-string-value>
     </result>
   </test-case>
+  
   <test-case name="map-filter-012">
     <description>Map with built-in predicate functions</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -98,6 +110,7 @@
       <assert-string-value>aba</assert-string-value>
     </result>
   </test-case>
+  
   <test-case name="map-filter-013">
     <description>Zero-arity predicate function</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -107,6 +120,7 @@
       <assert-deep-eq>map { 'abc': 'a', 'def': 'g' }</assert-deep-eq>
     </result>
   </test-case>
+  
   <test-case name="map-filter-014">
     <description>Invalid predicate function</description>
     <created by="Christian Gruen" on="2022-08-09"/>
@@ -115,4 +129,14 @@
       <error code="XPTY0004"/>
     </result>
   </test-case>
+  
+  <test-case name="map-filter-015" covers-40="PR1128">
+    <description>Predicate function returns ()</description>
+    <created by="Michael Kay" on="2024-05-05"/>
+    <test><![CDATA[map:filter(map { 'abc': 'a', 'def': 'g' }, fn($k,$v){if (starts-with($k, $v)){true()}})]]></test>
+    <result>
+      <assert-deep-eq>map { 'abc': 'a'}</assert-deep-eq>
+    </result>
+  </test-case>
+  
 </test-set>

--- a/map/keys-where.xml
+++ b/map/keys-where.xml
@@ -47,6 +47,7 @@ map:keys-where(
             <assert-eq>12</assert-eq>
         </result>
     </test-case>
+    
     <test-case name="map-keys-where-004">
         <description>Predicate function</description>
         <created by="Christian Gruen" on="2024-03-06"/>
@@ -58,6 +59,15 @@ map:keys-where(
         ]]></test>
         <result>
             <assert-eq>12</assert-eq>
+        </result>
+    </test-case>
+    
+    <test-case name="map-keys-where-005" covers-40="PR1128">
+        <description>Predicate function returns ()</description>
+        <created by="Michael Kay" on="2024-05-05"/>
+        <test><![CDATA[map:keys-where(map { 29: 82, 123: 456 }, function($v) { {29: true()}?$v} )]]></test>
+        <result>
+            <assert-deep-eq>29</assert-deep-eq>
         </result>
     </test-case>
 

--- a/prod/ChoiceItemType.xml
+++ b/prod/ChoiceItemType.xml
@@ -259,7 +259,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	parse-xml('<a/>') instance of (element(a) | document-node(element(a)) | comment())
-      ]]></test>)
+      ]]></test>
       <result>
          <assert-true/>
       </result>
@@ -270,7 +270,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	parse-xml('<b/>') instance of (element(a) | document-node(element(a)) | comment())
-      ]]></test>)
+      ]]></test>
       <result>
          <assert-false/>
       </result>
@@ -292,7 +292,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	(33, true(), current-date()) instance of (xs:boolean | xs:date | xs:dateTime | xs:numeric)+
-      ]]></test>)
+      ]]></test>
       <result>
          <assert-true/>
       </result>
@@ -303,7 +303,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	(33, true(), current-date(), 'x') instance of (xs:boolean | xs:date | xs:dateTime | xs:numeric)+
-      ]]></test>)
+      ]]></test>
       <result>
          <assert-false/>
       </result>
@@ -314,7 +314,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	let $x as (xs:integer | xs:string) := (1,3,5,"x")[4] return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <assert-type>xs:string</assert-type>
       </result>
@@ -325,7 +325,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	let $x as (xs:integer | xs:string) := parse-xml('<a>23</a>') return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <all-of>
             <assert-type>xs:integer</assert-type>
@@ -339,7 +339,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	let $x as (xs:string | xs:integer)* := (parse-xml('<a>23</a>'), 17) return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <all-of>
             <assert-deep-eq>"23", 17</assert-deep-eq>
@@ -352,7 +352,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	let $x as (xs:string | xs:integer | element(a))* := (parse-xml('<a>23</a>')/*, 17) return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <all-of>
             <assert>$result[1] instance of element(a)</assert>
@@ -368,7 +368,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	let $x as (xs:string | xs:integer | array(*))* := ([1,2,3], 1, 2) return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <all-of>
             <assert-deep-eq>[1, 2, 3], 1, 2</assert-deep-eq>
@@ -381,7 +381,7 @@
       <created by="Michael Kay" on="2024-04-10"/>
       <test><![CDATA[
       	let $x as (array(xs:string) | array(xs:integer) | xs:string | xs:integer)* := [1,2,3] return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <all-of>
             <assert-deep-eq>[1, 2, 3]</assert-deep-eq>
@@ -396,7 +396,7 @@
       <test><![CDATA[
       	let $x as (record(x as xs:positiveInteger, y as xs:negativeInteger) |
       	           record(y as xs:positiveInteger, x as xs:negativeInteger))* := {'x':-1, 'y':+1} return $x
-      ]]></test>)
+      ]]></test>
       <result>
          <all-of>
             <assert-deep-eq>{'x':-1, 'y':+1}</assert-deep-eq>

--- a/prod/FunctionDecl.xml
+++ b/prod/FunctionDecl.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="prod-FunctionDecl">
    <description>Tests for the FunctionDecl production</description>
    <link type="spec" document="http://www.w3.org/TR/xquery-30/"
@@ -2505,6 +2505,96 @@
       </test>
       <result>
          <assert-eq>15</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="function-decl-40-025" covers-40="PR1137">
+      <description>Variadic function</description>
+      <created by="Michael Kay" on="2024-04-30"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+         declare %variadic function local:product($x as xs:integer*) { 
+            if (empty($x)) then 1 else head($x) × local:product(tail($x))
+         };
+         local:product(1,2,3,4)
+      </test>
+      <result>
+         <assert-eq>24</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="function-decl-40-026" covers-40="PR1137">
+      <description>Variadic function</description>
+      <created by="Michael Kay" on="2024-04-30"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+         declare %variadic function local:product($x as xs:integer*) { 
+         if (empty($x)) then 1 else head($x) × local:product(tail($x))
+         };
+         local:product((1,2,3,4))
+      </test>
+      <result>
+         <assert-eq>24</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="function-decl-40-027" covers-40="PR1137">
+      <description>Variadic function</description>
+      <created by="Michael Kay" on="2024-04-30"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+         declare %variadic function local:product($x as xs:integer*) { 
+         if (empty($x)) then 1 else head($x) × local:product(tail($x))
+         };
+         local:product((1,2),(3,4))
+      </test>
+      <result>
+         <assert-eq>24</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="function-decl-40-028" covers-40="PR1137">
+      <description>Variadic function</description>
+      <created by="Michael Kay" on="2024-04-30"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+         declare %variadic function local:product($x as xs:integer*) { 
+         if (empty($x)) then 1 else head($x) × local:product(tail($x))
+         };
+         local:product(x := (1,2,3,4))
+      </test>
+      <result>
+         <assert-eq>24</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="function-decl-40-029" covers-40="PR1137">
+      <description>Variadic function</description>
+      <created by="Michael Kay" on="2024-04-30"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+         declare %variadic function local:product($x as xs:integer*) { 
+         if (empty($x)) then 1 else head($x) × local:product(tail($x))
+         };
+         local:product#4(1,2,3,4)
+      </test>
+      <result>
+         <assert-eq>24</assert-eq>
+      </result>
+   </test-case>
+   
+   <test-case name="function-decl-40-030" covers-40="PR1137">
+      <description>Variadic function</description>
+      <created by="Michael Kay" on="2024-04-30"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+         declare %variadic function local:product($x as xs:integer*) { 
+         if (empty($x)) then 1 else head($x) × local:product(tail($x))
+         };
+         local:product(1,2,?,4)(3)
+      </test>
+      <result>
+         <assert-eq>24</assert-eq>
       </result>
    </test-case>
    

--- a/prod/Lookup.xml
+++ b/prod/Lookup.xml
@@ -1211,7 +1211,7 @@
       <result>
          <assert-deep-eq>2</assert-deep-eq>
       </result>
-   </test-case>-->
+   </test-case>
    
    <test-case name="Lookup-411" covers-40="PR1125">
       <description>Type-qualified wildcard, multi-level selection</description>
@@ -1231,7 +1231,7 @@
       <result>
          <assert-deep-eq>2, 4</assert-deep-eq>
       </result>
-   </test-case>-->
+   </test-case>
    
    <test-case name="Lookup-413">
       <description>Issue 860: when the context value is a sequence and the key specifier is context dependent</description>

--- a/prod/Lookup.xml
+++ b/prod/Lookup.xml
@@ -1172,83 +1172,62 @@
       </result>
    </test-case>
    
-   <!--<test-case name="Lookup-405">
+   <test-case name="Lookup-405" covers-40="PR1125">
       <description>Type-qualified wildcard</description>
       <created by="Michael Kay" on="2023-11-26"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>
-         [1, 2, 3, "a", "b", "c"]?*::xs:string</test>
+         [1, 2, 3, "a", "b", "c"]?type(xs:string)</test>
       <result>
          <assert-deep-eq>"a", "b", "c"</assert-deep-eq>
       </result>
    </test-case>
    
-   <test-case name="Lookup-406">
+   <test-case name="Lookup-406" covers-40="PR1125">
       <description>Type-qualified wildcard</description>
       <created by="Michael Kay" on="2023-11-26"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[1, 2, 3, "a", "b", "c"]?*::xs:decimal</test>
+      <test>[1, 2, 3, "a", "b", "c"]?type(xs:decimal)</test>
       <result>
          <assert-deep-eq>1, 2, 3</assert-deep-eq>
       </result>
    </test-case>
    
-   <test-case name="Lookup-407">
+   <test-case name="Lookup-407" covers-40="PR1125">
       <description>Type-qualified wildcard, sequence type</description>
       <created by="Michael Kay" on="2023-11-26"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[1, (2, 3), (), "a", "b", "c"]?*::xs:decimal</test>
+      <test>[1, (2, 3), (), "a", "b", "c"]?type(xs:decimal+)</test>
       <result>
          <assert-deep-eq>1, 2, 3</assert-deep-eq>
       </result>
    </test-case>
    
-   <test-case name="Lookup-408">
-      <description>Type-qualified wildcard, sequence type</description>
-      <created by="Michael Kay" on="2023-11-26"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[1, (2, 3), (), "a", "b", "c"]?*::xs:decimal</test>
-      <result>
-         <assert-deep-eq>1, 2, 3</assert-deep-eq>
-      </result>
-   </test-case>
-   
-   <test-case name="Lookup-409">
-      <description>Type-qualified wildcard, sequence type</description>
-      <created by="Michael Kay" on="2023-11-26"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[1, (2, 3), (), "a", "b", "c"]?*::xs:decimal</test>
-      <result>
-         <assert-deep-eq>1, 2, 3</assert-deep-eq>
-      </result>
-   </test-case>
-   
-   <test-case name="Lookup-410">
+   <test-case name="Lookup-410" covers-40="PR1125">
       <description>Type-qualified wildcard, sequence type, parsing wierdness</description>
       <created by="Michael Kay" on="2023-11-26"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[1, (), "a", "b", "c"]?*::xs:decimal+++1</test>
+      <test>[1, (), "a", "b", "c"]?type(xs:decimal+)++1</test>
       <result>
          <assert-deep-eq>2</assert-deep-eq>
       </result>
    </test-case>-->
    
-   <!-- See issue 859 -->
-   <!--<test-case name="Lookup-411">
+   <test-case name="Lookup-411" covers-40="PR1125">
       <description>Type-qualified wildcard, multi-level selection</description>
       <created by="Michael Kay" on="2023-11-26"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[[1,2], [3,4], 5, 6]?*::array(*)?1</test>
+      <test>[[1,2], [3,4], 5, 6]?type(array(*))?1</test>
       <result>
          <assert-deep-eq>1, 3</assert-deep-eq>
       </result>
    </test-case>
    
-   <test-case name="Lookup-412">
+   <test-case name="Lookup-412" covers-40="PR1125">
       <description>Type-qualified wildcard, multi-level selection with filtering</description>
       <created by="Michael Kay" on="2023-11-26"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>[[1,2], [3,4], [8], 5, 6]?*::array(*)[array:size(.) gt 1]?2</test>
+      <test>[[1,2], [3,4], [8], 5, 6]?type(array(*))[array:size(.) gt 1]?2</test>
       <result>
          <assert-deep-eq>2, 4</assert-deep-eq>
       </result>

--- a/prod/WindowClause.xml
+++ b/prod/WindowClause.xml
@@ -2982,11 +2982,13 @@ return [ $w ]
   </test-case>
   <test-case name="WindowExprOptional26" covers-40="PR1131">
     <description> Type of position variables</description>
-    <created by="Michael Kay" on="2023-05-18"/>
+    <created by="Michael Kay" on="2024-05-06"/>
     <dependency type="spec" value="XQ40+"/>
-    <test>for tumbling window $w in 1 to 2 start $s at $sa previous $sp next $sn end $e at $ea previous $ep next $en return ($sa, $ea)</test>
+    <test>for tumbling window $w in 1 to 2 
+          start $s at $sa previous $sp next $sn 
+          end $e at $ea previous $ep next $en return ($sa, $ea)</test>
     <result>
-      <assert-type>xs:positiveInteger+</assert-type>
+      <assert-type>xs:integer+</assert-type>
     </result>
   </test-case>
 


### PR DESCRIPTION
Add tests for functions with a boolean callback that can now return an empty sequence