### PR TITLE
Expect coercion of xs:anyURI to enum to be rejected in test case DynamicFunctionCall-136

### DIFF
--- a/prod/DynamicFunctionCall.xml
+++ b/prod/DynamicFunctionCall.xml
@@ -597,13 +597,14 @@
       <description>Promotion for enumeration types</description>
       <created by="Michael Kay" on="2024-02-09"/>
       <modified by="Michael Kay" on="2024-04-18" change="new rules say promotion happens here"/>
+      <modified by="Gunther Rademacher" on="2024-06-07" change="no coercion from xs:anyURI to enum"/>
       <test>
          let $f := function($in as enum("a", "b", "c")) as xs:string {
             string($in)
          }
          return $f(xs:anyURI('a'))</test>
       <result>
-         <assert-string-value>a</assert-string-value>
+         <error code="XPTY0004"/>
       </result>
    </test-case>
    


### PR DESCRIPTION
If my reading of the spec, as explained in #135, is correct, test case `DynamicFunctionCall-136` should expect `XPTY0004`.