### PR TITLE
Change expected result of FunctionCall-422

### DIFF
--- a/prod/FunctionCall.xml
+++ b/prod/FunctionCall.xml
@@ -1308,10 +1308,11 @@
       <description>Partial application with a wrong-type argument. See issue 894</description>
       <created by="Michael Kay" on="2024-01-07"/>
       <modified by="Christian Gruen" on="2024-05-29" change="Return arity for partially applied functions"/>
+      <modified by="Gunther Rademacher" on="2024-07-28" change="Return type error, when coercion fails"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>function-arity(contains(?, 23))</test>
       <result>
-         <assert-eq>1</assert-eq>
+         <error code="XPTY0004"/>
       </result>
    </test-case>
    


### PR DESCRIPTION
Test case `FunctionCall-422` currently asks for a result of `1` from this query:

```xquery
function-arity(contains(?, 23))
```

However it should return a type error: `function-arity` has to return the arity of the function identified by the given function item, which in this case is constructed according to the rules provided in [4.5.2.3 Partial Function Application](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-partial-function-application). For static function calls they say:

> A type error is raised if any of the explicitly supplied or defaulted parameters, after applying the coercion rules, does not match the required type of the corresponding parameter.

This applies here - the explicitly supplied parameter has a type of `xs:integer`, but the type of the second parameter of `fn:contains` is `xs:string?`.

Admittedly, the arity only depends on the number of placeholders, so that it could also be evaluated by bypassing the above rule.

However, as the course of action is to construct a function item and then evaluate the arity of the function it identifies, we should expect a type error here.