### PR TITLE
Allow result from fn:function-arity where arity can be calculated despite some error

### DIFF
--- a/misc/HigherOrderFunctions.xml
+++ b/misc/HigherOrderFunctions.xml
@@ -2003,12 +2003,16 @@ return string($a)
    <test-case name="xqhof40">
       <description>Partial apply with invalid type argument. 4.0 mandates an error; 3.1 doesn't say.</description>
       <created by="Michael Kay" on="2023-12-12"/>
+      <modified by="Gunther Rademacher" on="2024-07-29" change="Allow result to be returned, alternative to type error."/>
       <dependency type="spec" value="XQ30+"/>
       <test>
          function-arity(contains(?, 42))
       </test>
       <result>
-         <error code="XPTY0004"/>
+         <any-of>
+            <assert-eq>1</assert-eq>
+            <error code="XPTY0004"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -2016,13 +2020,17 @@ return string($a)
       <description>Partial apply with invalid type argument, detected at evaluation time. 
          4.0 mandates an error; 3.1 doesn't say.</description>
       <created by="Michael Kay" on="2023-12-12"/>
+      <modified by="Gunther Rademacher" on="2024-07-29" change="Allow result to be returned, alternative to type error."/>
       <dependency type="spec" value="XQ30+"/>
       <test>
          let $p := if (current-date() lt xs:date('1900-01-01')) then 'abc' else 42
          return function-arity(contains(?, $p))
       </test>
       <result>
-         <error code="XPTY0004"/>
+         <any-of>
+            <assert-eq>1</assert-eq>
+            <error code="XPTY0004"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -2048,12 +2056,16 @@ return string($a)
          The spec mandates an error if the expression `name#0` is actually evaluated, but it's possible to
          determine the arity of a function without evaluating its body. There is no attempt to evaluate
          the function here, so I think there is no error."/>
+      <modified by="Gunther Rademacher" on="2024-07-29" change="Allow type error to be returned, alternative to result."/>
       <dependency type="spec" value="XQ30+"/>
       <test>
          let $f := fn($x){name#0} return function-arity($f)
       </test>
       <result>
-         <assert-eq>1</assert-eq>
+         <any-of>
+            <assert-eq>1</assert-eq>
+            <error code="XPDY0002"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -2061,12 +2073,16 @@ return string($a)
       <description>Function reference with incorrect context. 4.0 mandates an error; 3.1 doesn't say.</description>
       <created by="Michael Kay" on="2023-12-12"/>
       <modified by="Michael Kay" on="2024-07-22" change="See xqhof43"/>
+      <modified by="Gunther Rademacher" on="2024-07-29" change="Allow result to be returned, alternative to type error."/>
       <dependency type="spec" value="XQ30+"/>
       <test>
          let $f := fn($x){42!name#0} return function-arity($f)
       </test>
       <result>
-         <error code="XPTY0004"/>
+         <any-of>
+            <assert-eq>1</assert-eq>
+            <error code="XPTY0004"/>
+         </any-of>
       </result>
    </test-case>
    

--- a/prod/FunctionCall.xml
+++ b/prod/FunctionCall.xml
@@ -1309,10 +1309,14 @@
       <created by="Michael Kay" on="2024-01-07"/>
       <modified by="Christian Gruen" on="2024-05-29" change="Return arity for partially applied functions"/>
       <modified by="Gunther Rademacher" on="2024-07-28" change="Return type error, when coercion fails"/>
+      <modified by="Gunther Rademacher" on="2024-07-29" change="Allow result to be returned, alternative to type error."/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>function-arity(contains(?, 23))</test>
       <result>
-         <error code="XPTY0004"/>
+         <any-of>
+            <assert-eq>1</assert-eq>
+            <error code="XPTY0004"/>
+         </any-of>
       </result>
    </test-case>
    

--- a/prod/NamedFunctionRef.xml
+++ b/prod/NamedFunctionRef.xml
@@ -4890,6 +4890,7 @@
   <test-case name="named-function-ref-function-arity-902" covers-40="PR897">
     <description>Attempts to lookup a context-dependent function when there is no context item. QT4 issue 894</description>
     <created by="Michael Kay" on="2023-12-13"/>
+    <modified by="Gunther Rademacher" on="2024-07-29" change="Allow result to be returned, alternative to type error."/>
     <dependency type="spec" value="XQ40+"/>
     <test><![CDATA[
       declare function local:f() {
@@ -4898,7 +4899,10 @@
       function-arity(local:f())
     ]]></test>
     <result>
-      <error code="XPDY0002"/>
+      <any-of>
+         <assert-eq>0</assert-eq>
+         <error code="XPDY0002"/>
+      </any-of>
     </result>
   </test-case>
 


### PR DESCRIPTION
Following up on the discussion in qt4cg/qt4tests#148, these changes take care of allowing both a result and a type error from invocations of `fn:function-arity` in cases where the given function item
- refers to a non-executed function with errors in the function body
- is a partially applied function where some explicitly supplied parameter is not suitable.

This affects test cases
- `xqhof40`
- `xqhof41`
- `xqhof43`
- `xqhof44`
- `FunctionCall-422`
- `named-function-ref-function-arity-902`

Test case `named-function-ref-function-arity-902` is now identical to test case `named-function-ref-function-arity-901`, apart from its annotations. Should it rather be removed?