### PR TITLE
Expect XPST0051 for undefined type in test cases 

### DIFF
--- a/prod/ItemTypeDecl.xml
+++ b/prod/ItemTypeDecl.xml
@@ -100,7 +100,7 @@
          (not allowed)</description>
       <created by="Michael Kay" on="2023-09-08"/>
       <modified by="Michael Kay" on="2024-04-10" change="change local union type syntax"/>
-	  <modified by="Gunther Rademacher" on="2024-08-05" change="change expected error to XPST0051"/>
+      <modified by="Gunther Rademacher" on="2024-08-05" change="change expected error to XPST0051"/>
       <test><![CDATA[
          declare variable $fred as local:int-or-string := 17;
          declare item-type local:int-or-string as (xs:integer | xs:string);     	
@@ -147,7 +147,7 @@
       <description>local union type, used as function argument, forwards reference</description>
       <created by="Michael Kay" on="2023-09-08"/>
       <modified by="Michael Kay" on="2024-04-10" change="change local union type syntax"/>
-	  <modified by="Gunther Rademacher" on="2024-08-05" change="change expected error to XPST0051"/>
+      <modified by="Gunther Rademacher" on="2024-08-05" change="change expected error to XPST0051"/>
       <test><![CDATA[
          declare function local:increment ($val as local:int-or-string) as xs:integer {
       	    if ($val instance of xs:integer) then $val + 1 else string-length($val) + 1

--- a/prod/ItemTypeDecl.xml
+++ b/prod/ItemTypeDecl.xml
@@ -100,13 +100,14 @@
          (not allowed)</description>
       <created by="Michael Kay" on="2023-09-08"/>
       <modified by="Michael Kay" on="2024-04-10" change="change local union type syntax"/>
+	  <modified by="Gunther Rademacher" on="2024-08-05" change="change expected error to XPST0051"/>
       <test><![CDATA[
          declare variable $fred as local:int-or-string := 17;
          declare item-type local:int-or-string as (xs:integer | xs:string);     	
       	$fred
       ]]></test>
       <result>
-         <error code="XPST0003"/>
+         <error code="XPST0051"/>
       </result>
    </test-case>
    
@@ -146,6 +147,7 @@
       <description>local union type, used as function argument, forwards reference</description>
       <created by="Michael Kay" on="2023-09-08"/>
       <modified by="Michael Kay" on="2024-04-10" change="change local union type syntax"/>
+	  <modified by="Gunther Rademacher" on="2024-08-05" change="change expected error to XPST0051"/>
       <test><![CDATA[
          declare function local:increment ($val as local:int-or-string) as xs:integer {
       	    if ($val instance of xs:integer) then $val + 1 else string-length($val) + 1
@@ -154,7 +156,7 @@
       	(local:increment(17), local:increment("two"))
       ]]></test>
       <result>
-         <error code="XPST0003"/>
+         <error code="XPST0051"/>
       </result>
    </test-case>
    


### PR DESCRIPTION
In [3.2 Item Types](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-matching-item), the spec explains how to interpret an EQName occurring as an item type designator, and eventually it says:

> If the name cannot be resolved to a type, a [static error](https://qt4cg.org/specifications/xquery-40/xquery-40.html#dt-static-error) is raised [[err:XPST0051](https://qt4cg.org/specifications/xquery-40/xquery-40.html#ERRXPST0051)].

In contrast to this, `itemTypeDecl-007` and `itemTypeDecl-010` currently ask for a general parsing error [[err:XPST0003](https://qt4cg.org/specifications/xquery-40/xquery-40.html#ERRXPST0003)].

This change modifies the expected error code accordingly.