### PR TITLE
Improvements to tests for fn:parse-uri

### DIFF
--- a/fn/parse-uri.xml
+++ b/fn/parse-uri.xml
@@ -746,11 +746,11 @@ map {
   <test-case name="fn-parse-uri-043">
     <description>Parses a URI ending in "#"</description>
     <created by="Michael Kay" on="2023-10-27"/>
+    <modified by="Norm Tovey-Walsh" on="2024-08-13" change="remove fragment"/>
     <test>fn:parse-uri("https://qt4cg.org/specifications/xpath-functions-40/Overview.html#")</test>
     <result>
       <assert-deep-eq>map {
         "authority": "qt4cg.org",
-        "fragment": "",
         "host": "qt4cg.org",
         "path": "/specifications/xpath-functions-40/Overview.html",
         "path-segments": ("", "specifications", "xpath-functions-40", "Overview.html"),
@@ -1179,4 +1179,22 @@ map {
 }</assert-deep-eq>
     </result>
   </test-case>
+
+  <test-case name="fn-parse-uri-50">
+    <description>Discard an empty query string</description>
+    <create by="Norm Tovey-Walsh" on="2024-08-13"/>
+    <test>fn:parse-uri("https://example.com/?")</test>
+    <result>
+      <assert-deep-eq>map {
+        "authority": "example.com",
+        "host": "example.com",
+        "path": "/",
+        "path-segments": ("", ""),
+        "scheme": "https",
+        "hierarchical": true(),
+        "uri": "https://example.com/?"
+        }</assert-deep-eq>
+    </result>
+  </test-case>
+
 </test-set>


### PR DESCRIPTION
Fixes issues described in https://github.com/qt4cg/qtspecs/issues/1381 and adds a new tests for the proposed change to handling the query string (addressed in https://github.com/qt4cg/qtspecs/pull/1380)