### PR TITLE
Adapt test case `decimal-format-911err-a` to recent changes

### DIFF
--- a/prod/DecimalFormatDecl.xml
+++ b/prod/DecimalFormatDecl.xml
@@ -490,6 +490,8 @@
       <description>
         Purpose: Decimal format declaration declares invalid property value. </description>
       <created by="Michael Kay, Saxonica" on="2012-10-08"/>
+      <modified by="Gunther Rademacher" on="2024-12-03" change="spawned decimal-format-911err-a for XQ40+"/>
+      <dependency type="spec" value="XQ30 XQ31"/>
       <test>
         declare default decimal-format minus-sign="--";
         format-number(931.4857,'000.$$0')</test>
@@ -498,6 +500,19 @@
       </result>
    </test-case>
   
+   <test-case name="decimal-format-911err-a">
+      <description>
+        Purpose: Decimal format declaration with non-single-char minus-sign, but invalid picture. </description>
+      <created by="Gunther Rademacher" on="2024-12-03"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+        declare default decimal-format minus-sign="--";
+        format-number(931.4857,'000.$$0')</test>
+      <result>
+         <error code="FODF1310"/>
+      </result>
+   </test-case>
+
   <test-case name="decimal-format-912err">
     <description>
       Purpose: Test of decimal-format declaration with a property value clashing with a digit in the zero-digit family. </description>


### PR DESCRIPTION
Per qt4cg/qtspecs#1048, implemented by qt4cg/qtspecs#1250, and [test case `numberformat-550`](https://github.com/GuntherRademacher/qt4tests/blob/17d7b573ff9d2b5d056e4b3fbc9c8dd83466a693/fn/format-number.xml#L3772), a decimal format `minus-sign` may now be an arbitrary string, rather than a single character.

This change adapts test case `decimal-format-911err` accordingly by making it dependent on `XQ30` `XQ31` and spawing `decimal-format-911err-a` for `XQ40+`, expecting a different error code.