### PR TITLE
CSV parsing: trimmed headers

### DIFF
--- a/fn/csv-to-xml.xml
+++ b/fn/csv-to-xml.xml
@@ -689,7 +689,44 @@
           ></rows></csv>]]></assert-xml>
     </result>
   </test-case>-->
-  
+
+  <test-case name="csv-to-xml-088">
+    <description>Extracted headers are always trimmed</description>
+    <created by="Gunther Rademacher" on="2025-01-03"/>
+    <test>fn:csv-to-xml("  one,two  |three,four", 
+      map{'row-delimiter':'|', 'header':true()})</test>
+    <result>
+      <assert-xml><![CDATA[<csv xmlns="http://www.w3.org/2005/xpath-functions"><columns><column
+	      >one</column><column>two</column></columns><rows><row><field column="one">three</field
+		  ><field column="two">four</field></row></rows></csv>]]></assert-xml>
+    </result>
+  </test-case>
+
+  <test-case name="csv-to-xml-089">
+    <description>Extracted headers are trimmed even when trim-whitespace is false</description>
+    <created by="Gunther Rademacher" on="2025-01-03"/>
+    <test>fn:csv-to-xml("  one,two  |three,four", 
+      map{'row-delimiter':'|', 'header':true(), 'trim-whitespace':false()})</test>
+    <result>
+      <assert-xml><![CDATA[<csv xmlns="http://www.w3.org/2005/xpath-functions"><columns><column
+	      >one</column><column>two</column></columns><rows><row><field column="one">three</field
+		  ><field column="two">four</field></row></rows></csv>]]></assert-xml>
+    </result>
+  </test-case>
+
+  <test-case name="csv-to-xml-090">
+    <description>Explicit headers are not trimmed even when trim-whitespace is true</description>
+    <created by="Gunther Rademacher" on="2025-01-03"/>
+    <test>fn:csv-to-xml("  one,two  |three,four", 
+      map{'row-delimiter':'|', 'header':('   first', 'second   '), 'trim-whitespace':true()})</test>
+    <result>
+      <assert-xml><![CDATA[<csv xmlns="http://www.w3.org/2005/xpath-functions"><columns><column
+	      >   first</column><column>second   </column></columns><rows><row><field column="   first"
+		  >one</field><field column="second   ">two</field></row><row><field column="   first"
+		  >three</field><field column="second   ">four</field></row></rows></csv>]]></assert-xml>
+    </result>
+  </test-case>
+
   <test-case name="csv-to-xml-201">
     <description>Returned element is parentless</description>
     <created by="Michael Kay" on="2024-02-28"/>

--- a/fn/csv-to-xml.xml
+++ b/fn/csv-to-xml.xml
@@ -693,37 +693,40 @@
   <test-case name="csv-to-xml-088">
     <description>Extracted headers are always trimmed</description>
     <created by="Gunther Rademacher" on="2025-01-03"/>
-    <test>fn:csv-to-xml("  one,two  |three,four", 
+    <test>fn:csv-to-xml(' one,two ," three","four "| 1,2 , 3,4 ',
       map{'row-delimiter':'|', 'header':true()})</test>
     <result>
       <assert-xml><![CDATA[<csv xmlns="http://www.w3.org/2005/xpath-functions"><columns><column
-	      >one</column><column>two</column></columns><rows><row><field column="one">three</field
-		  ><field column="two">four</field></row></rows></csv>]]></assert-xml>
+	      >one</column><column>two</column><column>three</column><column>four</column></columns
+		  ><rows><row><field column="one"> 1</field><field column="two">2 </field><field column
+		  ="three"> 3</field><field column="four">4 </field></row></rows></csv>]]></assert-xml>
     </result>
   </test-case>
 
   <test-case name="csv-to-xml-089">
     <description>Extracted headers are trimmed even when trim-whitespace is false</description>
     <created by="Gunther Rademacher" on="2025-01-03"/>
-    <test>fn:csv-to-xml("  one,two  |three,four", 
+    <test>fn:csv-to-xml(' one,two ," three","four "| 1,2 , 3,4 ',
       map{'row-delimiter':'|', 'header':true(), 'trim-whitespace':false()})</test>
     <result>
       <assert-xml><![CDATA[<csv xmlns="http://www.w3.org/2005/xpath-functions"><columns><column
-	      >one</column><column>two</column></columns><rows><row><field column="one">three</field
-		  ><field column="two">four</field></row></rows></csv>]]></assert-xml>
+	      >one</column><column>two</column><column>three</column><column>four</column></columns
+		  ><rows><row><field column="one"> 1</field><field column="two">2 </field><field column
+		  ="three"> 3</field><field column="four">4 </field></row></rows></csv>]]></assert-xml>
     </result>
   </test-case>
 
   <test-case name="csv-to-xml-090">
     <description>Explicit headers are not trimmed even when trim-whitespace is true</description>
     <created by="Gunther Rademacher" on="2025-01-03"/>
-    <test>fn:csv-to-xml("  one,two  |three,four", 
+    <test>fn:csv-to-xml(' one,two ," three","four "| 1,2 , 3,4 ',
       map{'row-delimiter':'|', 'header':('   first', 'second   '), 'trim-whitespace':true()})</test>
     <result>
       <assert-xml><![CDATA[<csv xmlns="http://www.w3.org/2005/xpath-functions"><columns><column
-	      >   first</column><column>second   </column></columns><rows><row><field column="   first"
-		  >one</field><field column="second   ">two</field></row><row><field column="   first"
-		  >three</field><field column="second   ">four</field></row></rows></csv>]]></assert-xml>
+	      >   first</column><column>second   </column></columns><rows><row><field column=
+		  "   first">one</field><field column="second   ">two</field><field>three</field><field
+		  >four</field></row><row><field column="   first">1</field><field column="second   "
+		  >2</field><field>3</field><field>4</field></row></rows></csv>]]></assert-xml>
     </result>
   </test-case>
 

--- a/fn/parse-csv.xml
+++ b/fn/parse-csv.xml
@@ -830,8 +830,47 @@
        <assert-deep-eq>["d","c","b","s","r","q"]</assert-deep-eq>
      </result>
    </test-case> 
-  
-  
+
+  <test-case name="parse-csv-103">
+    <description>Extracted headers are always trimmed</description>
+    <created by="Gunther Rademacher" on="2025-01-03"/>
+    <test>fn:parse-csv("  one,two  |three,four", 
+      map{'row-delimiter':'|', 'header':true()})</test>
+    <result>
+      <assert>deep-equal($result => map:remove("get"), 
+        map{"columns":("one","two"), 
+        "column-index": map{"one":1, "two":2}, 
+        "rows":["three","four"]})</assert>
+    </result>
+  </test-case>
+
+  <test-case name="parse-csv-104">
+    <description>Extracted headers are trimmed even when trim-whitespace is false</description>
+    <created by="Gunther Rademacher" on="2025-01-03"/>
+    <test>fn:parse-csv("  one,two  |three,four", 
+      map{'row-delimiter':'|', 'header':true(), 'trim-whitespace':false()})</test>
+    <result>
+      <assert>deep-equal($result => map:remove("get"), 
+        map{"columns":("one","two"), 
+        "column-index": map{"one":1, "two":2}, 
+        "rows":["three","four"]})</assert>
+    </result>
+  </test-case>
+
+  <test-case name="parse-csv-105">
+    <description>Explicit headers are not trimmed even when trim-whitespace is true</description>
+    <created by="Gunther Rademacher" on="2025-01-03"/>
+    <test>fn:parse-csv("  one,two  |three,four", 
+      map{'row-delimiter':'|', 'header':('   first', 'second   '), 'trim-whitespace':true()})</test>
+    <result>
+      <assert>deep-equal($result => map:remove("get"), 
+        map{"columns":("   first","second   "), 
+        "column-index": map{"   first":1, "second   ":2}, 
+        "rows":(["one","two"],["three","four"])})</assert>
+    </result>
+  </test-case>
+
+
   <test-case name="parse-csv-901">
     <description>Unclosed quotes</description>
     <created by="Michael Kay" on="2024-03-07"/>

--- a/fn/parse-csv.xml
+++ b/fn/parse-csv.xml
@@ -834,39 +834,39 @@
   <test-case name="parse-csv-103">
     <description>Extracted headers are always trimmed</description>
     <created by="Gunther Rademacher" on="2025-01-03"/>
-    <test>fn:parse-csv("  one,two  |three,four", 
+    <test>fn:parse-csv(' one,two ," three","four "| 1,2 , 3,4 ', 
       map{'row-delimiter':'|', 'header':true()})</test>
     <result>
       <assert>deep-equal($result => map:remove("get"), 
-        map{"columns":("one","two"), 
-        "column-index": map{"one":1, "two":2}, 
-        "rows":["three","four"]})</assert>
+        map{"columns":("one","two","three","four"), 
+        "column-index": map{"one":1, "two":2, "three": 3, "four": 4}, 
+        "rows":[" 1","2 "," 3","4 "]})</assert>
     </result>
   </test-case>
 
   <test-case name="parse-csv-104">
     <description>Extracted headers are trimmed even when trim-whitespace is false</description>
     <created by="Gunther Rademacher" on="2025-01-03"/>
-    <test>fn:parse-csv("  one,two  |three,four", 
+    <test>fn:parse-csv(' one,two ," three","four "| 1,2 , 3,4 ', 
       map{'row-delimiter':'|', 'header':true(), 'trim-whitespace':false()})</test>
     <result>
       <assert>deep-equal($result => map:remove("get"), 
-        map{"columns":("one","two"), 
-        "column-index": map{"one":1, "two":2}, 
-        "rows":["three","four"]})</assert>
+        map{"columns":("one","two","three","four"), 
+        "column-index": map{"one":1, "two":2, "three": 3, "four": 4}, 
+        "rows":[" 1","2 "," 3","4 "]})</assert>
     </result>
   </test-case>
 
   <test-case name="parse-csv-105">
     <description>Explicit headers are not trimmed even when trim-whitespace is true</description>
     <created by="Gunther Rademacher" on="2025-01-03"/>
-    <test>fn:parse-csv("  one,two  |three,four", 
-      map{'row-delimiter':'|', 'header':('   first', 'second   '), 'trim-whitespace':true()})</test>
+    <test>fn:parse-csv(' one,two ," three","four "| 1,2 , 3,4 ', 
+      map{'row-delimiter':'|', 'header':(' first', 'second ', ' third', 'fourth '), 'trim-whitespace':true()})</test>
     <result>
       <assert>deep-equal($result => map:remove("get"), 
-        map{"columns":("   first","second   "), 
-        "column-index": map{"   first":1, "second   ":2}, 
-        "rows":(["one","two"],["three","four"])})</assert>
+        map{"columns":(" first","second ", " third", "fourth "), 
+        "column-index": map{" first":1, "second ":2, " third":3, "fourth ":4}, 
+        "rows":(["one","two","three","four"], ["1", "2", "3", "4"])})</assert>
     </result>
   </test-case>
 


### PR DESCRIPTION
According to [14.4.6 Record fn:parsed-csv-structure-record](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#parsed-csv-structure-record), extracted column names always have leading and trailing whitespace trimmed:

> With `"header":true()`, the value is a sequence of strings taken from the first row of the data. The strings have leading and trailing whitespace trimmed, regardless of the value of the `trim-whitespace` option.

There is no test case that verifies this behavior yet, so I am here adding corresponding tests for `fn:parse-csv` and `fn:csv-to-xml`.