### PR TITLE
Percent-encode the space in the URI

### DIFF
--- a/fn/build-uri.xml
+++ b/fn/build-uri.xml
@@ -414,7 +414,7 @@
   "path-segments": ("file:", "C:", "Program Files", "test.jar!", "foo", "bar")
 })</test>
     <result>
-      <assert-eq>"jar:file:/C:/Program Files/test.jar!/foo/bar"</assert-eq>
+      <assert-eq>"jar:file:/C:/Program%20Files/test.jar!/foo/bar"</assert-eq>
     </result>
   </test-case>
 


### PR DESCRIPTION
I think the assertion

```xml
      <assert-eq>"jar:file:/C:/Program Files/test.jar!/foo/bar"</assert-eq>
```

in `fn-build-uri-from-parse-028` is an error on my part. (I'm not sure how I passed this test, tbh.)

Spaces in URIs are generally a bad idea and there's plenty of evidence on the web that spaces in `jar:` URIs are not correct.