### PR TITLE
Integrate expath binary tests

### DIFF
--- a/bin/and.xml
+++ b/bin/and.xml
@@ -1,0 +1,145 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-and">
+  <description>Tests for the bin:and function</description>
+  
+  <environment name="EXPath-binary-bitwise">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
+    <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>
+    <param name="c" select="xs:base64Binary(xs:hexBinary('0FABCD'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-bitwise-and-001">
+    <description>bitwise-and with differing lengths</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:and($a,$c) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-and-002">
+    <description>bitwise-and on empty sequences</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:and((),()) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-and-003">
+    <description>bitwise-and with data and empty sequence</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2013-11-13" change="change to empty sequence result"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:and($a,()) </test>
+    <result>
+      <assert-empty/>
+      <!--<error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>-->
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-and-004">
+    <description>bitwise-and with empty sequence and data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2013-11-13" change="change to empty sequence result"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:and((),$a) </test>
+    <result>
+      <assert-empty/>
+      <!--<error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>-->
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-and-005">
+    <description>bitwise-and on empty binaries</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:and($empty.bin,$empty.bin) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary('')</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-and-006">
+    <description>bitwise-and with similar lengths</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:and($a,$b) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary("0000"))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-and1">
+    <description>Test for the and function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:and((), xs:base64Binary(xs:hexBinary("00"))))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-and2">
+    <description>Test for the and function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:and(xs:base64Binary(xs:hexBinary("00")), ()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-and3">
+    <description>Test for the and function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:and(xs:base64Binary(xs:hexBinary("")), xs:base64Binary(xs:hexBinary(""))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-and4">
+    <description>Test for the and function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:and(xs:base64Binary(xs:hexBinary("8081")), xs:base64Binary(xs:hexBinary("7F7E"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-and5">
+    <description>Test for the and function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:and(xs:base64Binary(xs:hexBinary("00")), xs:base64Binary(xs:hexBinary("")))</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>
+    </result>
+  </test-case>
+ 
+  
+</test-set>

--- a/bin/bin.xml
+++ b/bin/bin.xml
@@ -1,0 +1,200 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-bin">
+  <description>Tests for the bin:bin unction</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-bin-001">
+    <description>Generate a zero-length binary from an empty binary string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:bin("") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bin-002">
+    <description>Generate an empty sequence from an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:bin(()) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bin-003">
+    <description>Generate a binary from an eight-multiple binary string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:bin("010011010110000101101110") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bin-004">
+    <description>Generate a binary from a non-eight-multiple binary string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:bin("011010110000101101110") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("DWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bin-005">
+    <description>Parsing error in binary string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:bin("0100a1010110000101101110") </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}non-numeric-character"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin1">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin(()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin2">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin(""))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin3">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("0"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin4">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("00"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin5">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("000000000"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin6">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("1"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("01")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin7">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("10"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("02")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin8">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("11111111"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin9">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:bin("111111111"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("01FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin10">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:bin("1101000111010101")</test>
+    <result>
+      <assert-eq>xs:base64Binary("0dU=")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin11">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:bin("1000111010101")</test>
+    <result>
+      <assert-eq>xs:base64Binary("EdU=")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-bin12">
+    <description>Test for the bin function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:bin("X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}non-numeric-character"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/decode-string.xml
+++ b/bin/decode-string.xml
@@ -1,0 +1,320 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-decode-string">
+  <description>Tests for the bin:decode-string function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  
+  <dependency type="feature" value="binary"/>
+  
+  
+  <test-case name="EXPath-binary-decode-string-001">
+    <description>decode-string on an empty sequence</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string((),"utf-8") </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-002">
+    <description>decode-string on empty binary data</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string($empty.bin,"utf-8") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>""</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-003">
+    <description>decode-string with unknown encoding</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string($empty.bin,"NOTutf-8") </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-encoding"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-004">
+    <description>decode-string on non-empty binary data</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(bin:encode-string("Simple &#xa3; text","utf-8"),"utf-8") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"Simple &#xa3; text"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-005">
+    <description>decode-string on non-empty binary data</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"A&#xea;&#xf1;&#xfc;C"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-006">
+    <description>decode-string on non-empty binary data, converted from octets</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(bin:from-octets((65,195,170,195,177,195,188,67)),"utf-8") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"A&#xea;&#xf1;&#xfc;C"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-007">
+    <description>decode-string with offset</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8",3) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"&#xf1;&#xfc;C"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-008">
+    <description>decode-string with offset and size</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8",3,4) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"&#xf1;&#xfc;"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-009">
+    <description>decode-string with negative offset</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8",-3,4) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-010">
+    <description>decode-string with negative size</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8",3,-4) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-011">
+    <description>decode-string with offset+size beyond data</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8",3,6) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-012">
+    <description>decode-string with code phasing mismatch in UTF-8</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8",2) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}conversion-error"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-013">
+    <description>decode-string on non-empty binary data in UTF-16</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary(
+                xs:hexBinary("feff00540068006900730020006900730020005500540046002d00310036")),
+                "utf-16") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"This is UTF-16"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-014">
+    <description>decode-string on non-empty binary data in UTF-16 with big-endian
+                BOM</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary(xs:hexBinary("feff011e")),"utf-16") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+        <assert-eq>"&#x11e;"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-015">
+    <description>decode-string on non-empty binary data in UTF-16 with little endian
+                BOM</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary(xs:hexBinary("fffe1e01")),"utf-16") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:string</assert-type>
+
+        <assert-eq>"&#x11e;"</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-decode-string-016">
+    <description>decode-string on non-empty binary data with default encoding</description>
+    <created by="John Lumley" on="2013-11-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:decode-string(xs:base64Binary("QcOqw7HDvEM=")) =
+                bin:decode-string(xs:base64Binary("QcOqw7HDvEM="),"utf-8") </test>
+    <result>
+      <all-of>
+        <assert-true/>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string1">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <modified by="John Lumley" on="2014-08-13" change="changed assertion type to string from integer"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("3132")), "US-ASCII")</test>
+    <result>
+      <assert-eq>'12'</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string2">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("3132")), "UTF-8")</test>
+    <result>
+      <assert-eq>'12'</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string3">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("313233")), "UTF-8", 1, 1)</test>
+    <result>
+      <assert-eq>'2'</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string4">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("")), "UTF-8", -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string5">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("")), "UTF-8", 0, -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string6">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("")), "UTF-8", 1, 0)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string7">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("")), "UTF-8", 0, 1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string8">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("")), "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-encoding"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-decode-string9">
+    <description>Test for the decode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:decode-string(xs:base64Binary(xs:hexBinary("FF")), "UTF-8")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}conversion-error"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/encode-string.xml
+++ b/bin/encode-string.xml
@@ -1,0 +1,171 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-encode-string">
+  <description>Tests for the bin:encode-string function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-encode-string-001">
+    <description>encode-string on an empty string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:encode-string("","utf-8") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-002">
+    <description>encode-string with unknown encoding</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:encode-string("","NOTutf-8") </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-encoding"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-003">
+    <description>encode-string on a non-empty string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:encode-string("A&#xea;&#xf1;&#xfc;C","utf-8") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("QcOqw7HDvEM=")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-004">
+    <description>encode-string on a non-empty string, converted to octets</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:to-octets(bin:encode-string("A&#xea;&#xf1;&#xfc;C","utf-8")) </test>
+    <result>
+      <assert-deep-eq>(65,195,170,195,177,195,188,67)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-005">
+    <description>encode-string on a non-empty string - UTF-16 - no control over BOM
+        Note (MHK 2021-06-21): the expected results assume UTF-16BE with BOM. This
+        isn't mandated by the spec, but it seems a reasonable thing to aim for.
+      </description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> xs:hexBinary(bin:encode-string("This is UTF-16","utf-16")) </test>
+    <result>
+      <assert-eq>xs:hexBinary("feff00540068006900730020006900730020005500540046002d00310036")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-006">
+    <description>
+        encode-string on a non-empty string - UTF-16 - no control over BOM.
+        Note (MHK 2021-06-21): the expected results assume UTF-16BE with BOM. This
+        isn't mandated by the spec, but it seems a reasonable thing to aim for.
+      </description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> xs:hexBinary(bin:encode-string("&#x11e;","utf-16")) </test>
+    <result>
+      <assert-eq>xs:hexBinary("feff011e")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-007">
+    <description>encode-string on a non-empty string using default encoding</description>
+    <created by="John Lumley" on="2013-11-19"/>
+    <modified by="John Lumley" on="2014-08-12" change="Replace non-ASCII by encodings"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:encode-string("A&#xea;&#xf1;&#xfc;C") =
+                bin:encode-string("A&#xea;&#xf1;&#xfc;C","utf-8") </test>
+    <result>
+      <all-of>
+        <assert-true/>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-encode-string-008">
+    <description>encode-string with unsupported character</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:encode-string("&#xa3;","US-ASCII") </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}conversion-error"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-encode-string1">
+    <description>Test for the encode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:encode-string("", "US-ASCII"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-encode-string2">
+    <description>Test for the encode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:encode-string("a", "US-ASCII"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("61")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-encode-string3">
+    <description>Test for the encode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:encode-string("&#196;", "UTF-8"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("C384")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-encode-string4">
+    <description>Test for the encode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:encode-string("", "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-encoding"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-encode-string5">
+    <description>Test for the encode-string function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:encode-string("&#196;", "US-ASCII")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}conversion-error"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/find.xml
+++ b/bin/find.xml
@@ -1,0 +1,163 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-find">
+  <description>Tests for the bin:find function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-find-001">
+    <description>find on an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find((),0,xs:base64Binary("TWFuAAAA")) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-find-002">
+    <description>find with an empty search sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2013-11-25" change="Empty search supported"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find(xs:base64Binary("TWFuAAAA"),1,xs:base64Binary("")) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-find-003">
+    <description>find with negative offset</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find(xs:base64Binary("AE1hbg=="),-1,xs:base64Binary("TWFu")) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-find-004">
+    <description>find with offset beyond input</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find(xs:base64Binary("AE1hbg=="),5,xs:base64Binary("TWFu")) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-find-005">
+    <description>find with search sequence absent from target</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find(xs:base64Binary("AE1hbg=="),2,xs:base64Binary("TWFu")) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-find-006">
+    <description>find under normal operation</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find(xs:base64Binary("AE1hbg=="),0,xs:base64Binary("TWFu")) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-find-007">
+    <description>find under normal operation</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:find(xs:base64Binary("TWFuAA=="),0,xs:base64Binary("TWFu")) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-find1">
+    <description>Test for the find function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:find(xs:base64Binary(xs:hexBinary("1122")), 0, xs:base64Binary(xs:hexBinary("11")))</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-find2">
+    <description>Test for the find function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:find(xs:base64Binary(xs:hexBinary("1122")), 1, xs:base64Binary(xs:hexBinary("11")))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-find3">
+    <description>Test for the find function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:find(xs:base64Binary(xs:hexBinary("112233")), 0, xs:base64Binary(xs:hexBinary("22")))</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-find4">
+    <description>Test for the find function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:find(xs:base64Binary(xs:hexBinary("")), -1, xs:base64Binary(xs:hexBinary("11")))</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-find5">
+    <description>Test for the find function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:find(xs:base64Binary(xs:hexBinary("")), 1, xs:base64Binary(xs:hexBinary("11")))</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-find6">
+    <description>Test for the find function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:find(xs:base64Binary(xs:hexBinary("")), 0, xs:base64Binary(xs:hexBinary("")))</test>
+    <result>
+      <assert-eq>0</assert-eq>
+      <!--<error code="Q{http://expath.org/ns/binary}empty-search-item"/>-->
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/from-octets.xml
+++ b/bin/from-octets.xml
@@ -1,0 +1,116 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-from-octets">
+  <description>Tests for the bin:from-octets unction</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-from-octets-001">
+    <description>Generate a zero-length binary from an empty set of octets</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:from-octets(()) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-from-octets-002">
+    <description>Generate a 4-length binary from a triple of octets</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:from-octets($man.octets) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-from-octets-003">
+    <description>Negative integer outside octet range in binary construction</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:from-octets((-77,97,110)) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-from-octets-004">
+    <description>Positive integer outside octet range in binary construction</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:from-octets((277,97,110)) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-from-octets1">
+    <description>Test for the from-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:from-octets(0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-from-octets2">
+    <description>Test for the from-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:from-octets((1,127)))</test>
+    <result>
+      <assert-eq>xs:hexBinary("017F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-from-octets3">
+    <description>Test for the from-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:from-octets((128,255)))</test>
+    <result>
+      <assert-eq>xs:hexBinary("80FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-from-octets4">
+    <description>Test for the from-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:from-octets(-1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-from-octets5">
+    <description>Test for the from-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:from-octets(256)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/hex.xml
+++ b/bin/hex.xml
@@ -1,0 +1,221 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-hex">
+  <description>Tests for the bin:hex function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-hex-001">
+    <description>Generate a zero-length binary from an empty hex string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:hex("") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-hex-002">
+    <description>hex - Generate an empty sequence from an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:hex(()) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-hex-003">
+    <description>Generate a binary from a two-multiple hex string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:hex("4D616E") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFu")</assert-eq>
+        <assert-eq>xs:base64Binary(xs:hexBinary("4D616E"))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-hex-004">
+    <description>Generate a binary from a non-two-multiple hex string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:hex("D616E") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("DWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-hex-005">
+    <description>Parsing error in hex string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:hex("4X616E") </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}non-numeric-character"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex1">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex(()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex2">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex(""))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex3">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("1"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("01")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex4">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("FF"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex5">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("111"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0111")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex6">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("FFF"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0FFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex7">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("000"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex8">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("FFFFF"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0FFFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex9">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("FFFFFFFFFFFFF"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0FFFFFFFFFFFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex10">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("10000000000000"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("10000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex11">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:hex("10000000000000"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("10000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex12">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:hex("11223F4E")</test>
+    <result>
+      <assert-eq>xs:base64Binary("ESI/Tg==")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex13">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:hex("1223F4E")</test>
+    <result>
+      <assert-eq>xs:base64Binary("ASI/Tg==")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-hex14">
+    <description>Test for the hex function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:hex("X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}non-numeric-character"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/insert-before.xml
+++ b/bin/insert-before.xml
@@ -1,0 +1,201 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-insert-before">
+  <description>Tests for the bin:insert-before function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+ 
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-insert-before-001">
+    <description>Insert-before with an empty sequence</description>
+    <created by="John Lumley" on="2013-08-06"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:insert-before((),0,$man.base) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-insert-before-002">
+    <description>Insert-before with negative offset</description>
+    <created by="John Lumley" on="2013-08-06"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:insert-before($man.base,-1,$man.base) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-insert-before-003">
+    <description>Insert-before: offset beyond end of input</description>
+    <created by="John Lumley" on="2013-08-06"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:insert-before($man.base,4,$man.base) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-insert-before-004">
+    <description>Insert-before with an empty extra</description>
+    <created by="John Lumley" on="2013-08-06"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:insert-before($man.base,0,()) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-insert-before-005">
+    <description>Insert-before of two sequences with zero offset</description>
+    <created by="John Lumley" on="2013-08-06"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:insert-before($man.base,0,$man.base) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFuTWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-insert-before-006">
+    <description>Insert-before of two sequences</description>
+    <created by="John Lumley" on="2013-08-06"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:to-octets(bin:insert-before($man.base,2,$man.base)) </test>
+    <result>
+      <all-of>
+        <assert-deep-eq>(77,97,77,97,110,110)</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before1">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before((), 0, ()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before2">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("12")), 0, ()))</test>
+    <result>
+      <assert-eq>xs:hexBinary("12")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before3">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("12")), 1, ()))</test>
+    <result>
+      <assert-eq>xs:hexBinary("12")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before4">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("1234")), 0, xs:base64Binary(xs:hexBinary("56"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("561234")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before5">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("1234")), 1, xs:base64Binary(xs:hexBinary("56"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("125634")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before6">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("1234")), 2, xs:base64Binary(xs:hexBinary("56"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("123456")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before7">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("12")), 0, xs:base64Binary(xs:hexBinary("3456"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("345612")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before8">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("12")), 1, xs:base64Binary(xs:hexBinary("3456"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("123456")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before9">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:insert-before(xs:base64Binary(xs:hexBinary("12")), 1, xs:base64Binary(xs:hexBinary("34"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("1234")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before10">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:insert-before(xs:base64Binary(xs:hexBinary("")), -1, ())</test>
+    <result>
+      <assert-eq>xs:base64Binary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-insert-before11">
+    <description>Test for the insert-before function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:insert-before(xs:base64Binary(xs:hexBinary("")), 1, ())</test>
+    <result>
+      <assert-eq>xs:base64Binary("")</assert-eq>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/join.xml
+++ b/bin/join.xml
@@ -1,0 +1,109 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-join">
+  <description>Tests for the bin:join function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+   
+ <test-case name="EXPath-binary-join-001">
+    <description>Join of an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:join(()) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-join-002">
+    <description>Join of two sequences</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:join(($man.base,$man.base)) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFuTWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-join-003">
+    <description>Join with type mismatch sequences</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-13" change="Admit static type-check errors"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:join(($man.base,123)) </test>
+    <result>
+      <any-of>
+        <error code="Q{http://www.w3.org/2005/xqt-errors}FORG0006"/>
+        <error code="Q{http://www.w3.org/2005/xqt-errors}XPTY0004"/>
+      </any-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-join1">
+    <description>Test for the join function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:join(()))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-join2">
+    <description>Test for the join function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:join(xs:base64Binary(xs:hexBinary(""))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-join3">
+    <description>Test for the join function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:join(xs:base64Binary(xs:hexBinary("FF"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-join4">
+    <description>Test for the join function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:join((xs:base64Binary(xs:hexBinary("FF")), xs:base64Binary(xs:hexBinary("FF")))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-join5">
+    <description>Test for the join function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <modified by="John Lumley" on="2014-10-02" change="dependent on XP30"/>
+    <environment ref="EXPath-binary"/>
+    <dependency type="spec" value="XP30+ XQ30+"/>
+    <test>xs:hexBinary(bin:join((1 to 3) ! xs:base64Binary(xs:hexBinary("11"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("111111")</assert-eq>
+    </result>
+  </test-case>
+  
+</test-set>

--- a/bin/length.xml
+++ b/bin/length.xml
@@ -1,0 +1,71 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-length">
+  <description>Tests for the bin:length function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-length-001">
+    <description>Use length on an empty value</description>
+    <created by="Michael Kay" on="2013-07-11"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:length(xs:base64Binary("")) </test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-length-002">
+    <description>Use length on an quadruple octet value</description>
+    <created by="John Lumley" on="2013-07-16"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:length(xs:base64Binary(xs:hexBinary("face1234"))) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>4</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-length1">
+    <description>Test for the length function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:length(xs:base64Binary(xs:hexBinary("")))</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-length2">
+    <description>Test for the length function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:length(xs:base64Binary(xs:hexBinary("FF")))</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-length3">
+    <description>Test for the length function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:length(xs:base64Binary(xs:hexBinary("12345678")))</test>
+    <result>
+      <assert-eq>4</assert-eq>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/not.xml
+++ b/bin/not.xml
@@ -1,0 +1,79 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-not">
+  <description>Tests for the bin:not function</description>
+  
+  <environment name="EXPath-binary-bitwise">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
+    <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>
+    <param name="c" select="xs:base64Binary(xs:hexBinary('0FABCD'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-bitwise-not-001">
+    <description>bitwise-not with empty data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:not($empty.bin) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary(""))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-not-002">
+    <description>bitwise-not with non-empty data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:not($a) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary("0FF0"))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-not1">
+    <description>Test for the not function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:not(()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-not2">
+    <description>Test for the not function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:not(xs:base64Binary(xs:hexBinary("00"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-not3">
+    <description>Test for the not function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:not(xs:base64Binary(xs:hexBinary("8081"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7F7E")</assert-eq>
+    </result>
+  </test-case>
+ 
+  
+</test-set>

--- a/bin/octal.xml
+++ b/bin/octal.xml
@@ -1,0 +1,190 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-octal">
+  <description>Tests for the bin:octal function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-octal-001">
+    <description>Generate a zero-length binary from an empty octal string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:octal("") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-octal-002">
+    <description>octal - Generate an empty sequence from an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:octal(()) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-octal-003">
+    <description>Generate a binary from byte-aligned octal string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:octal("23260556") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-octal-004">
+    <description>Generate a binary from a non-byte-aligned string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:octal("3260556") </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("DWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-octal-005">
+    <description>Parsing error in octal string</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:octal("8260556") </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}non-numeric-character"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal1">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:octal(())</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal2">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal(""))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal3">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("0"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal4">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("00"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal5">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("000"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal6">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("007"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0007")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal7">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("1"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("01")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal8">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("10"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("08")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal9">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:octal("77"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal10">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:octal("11223047")</test>
+    <result>
+      <assert-eq>xs:base64Binary("JSYn")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-octal11">
+    <description>Test for the octal function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:octal("X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}non-numeric-character"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/or.xml
+++ b/bin/or.xml
@@ -1,0 +1,146 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-or">
+  <description>Tests for the bin:or function</description>
+  
+  <environment name="EXPath-binary-bitwise">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
+    <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>
+    <param name="c" select="xs:base64Binary(xs:hexBinary('0FABCD'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-bitwise-or-001">
+    <description>bitwise-or with differing lengths</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:or($a,$c) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-or-002">
+    <description>bitwise-or on empty sequences</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:or((),()) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-or-003">
+    <description>bitwise-or with data and empty sequence</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2013-11-13" change="change to empty sequence result"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:or($a,()) </test>
+    <result>
+      <assert-empty/>
+      <!-- <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>-->
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-or-004">
+    <description>bitwise-or with empty sequence and data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2013-11-13" change="change to empty sequence result"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:or((),$a) </test>
+    <result>
+      <assert-empty/>
+      <!--<error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>-->
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-or-005">
+    <description>bitwise-or on empty binaries</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:or($empty.bin,$empty.bin) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary('')</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-or-006">
+    <description>bitwise-or with similar lengths</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:or($a,$b) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary("FFFF"))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-or1">
+    <description>Test for the or function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:or((), xs:base64Binary(xs:hexBinary("00"))))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-or2">
+    <description>Test for the or function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:or(xs:base64Binary(xs:hexBinary("00")), ()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-or3">
+    <description>Test for the or function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:or(xs:base64Binary(xs:hexBinary("")), xs:base64Binary(xs:hexBinary(""))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-or4">
+    <description>Test for the or function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:or(xs:base64Binary(xs:hexBinary("8081")), xs:base64Binary(xs:hexBinary("7F7E"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-or5">
+    <description>Test for the or function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:or(xs:base64Binary(xs:hexBinary("00")), xs:base64Binary(xs:hexBinary("")))</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>
+    </result>
+  </test-case>
+
+ 
+  
+</test-set>

--- a/bin/pack-double.xml
+++ b/bin/pack-double.xml
@@ -1,0 +1,313 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-pack-double">
+  <description>Tests for the bin:pack-double function</description>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+ 
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-pack-double-001">
+    <description>pack-double with unknown octet-order</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-double(xs:double(0.0),'MOST-sign-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-002">
+    <description>pack-double with 0.0 - little endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-double(xs:double(0.0)) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AAAAAAAAAAA=")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-003">
+    <description>pack-double with +0.0 - big-endian. Note the difference from IEEE regarding no
+        negative zero - in that case the leading octet is 128</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(+xs:double(0.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(0,0,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-004">
+    <description>pack-double with -0.0 - big-endian. Note the difference from IEEE regarding no
+        negative zero - in that case the leading octet is 128</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(-xs:double(0.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(128,0,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-005">
+    <description>pack-double with 1.0 - little-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(xs:double(1.0),'LE')) </test>
+    <result>
+      <assert-deep-eq>(0,0,0,0,0,0,240,63)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-006">
+    <description>pack-double with 1.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(xs:double(1.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(63,240,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-007">
+    <description>pack-double with 1.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-double(xs:double(1.0),'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary('3ff0000000000000'))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-008">
+    <description>pack-double with 2.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(xs:double(2.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(64,0,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-009">
+    <description>pack-double with positive infinity - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(1 div 0e0,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,240,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-010">
+    <description>pack-double with negative infinity - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(-1 div 0e0,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(255,240,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-double-011">
+    <description>pack-double with NaN - big-endian. Possibilities of other NaN
+        values?</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-double(number("NaN"),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,248,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double1">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double2">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3FF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double3">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(-1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("BFF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double4">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(-0e0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("8000000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double5">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(0e0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double6">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(xs:double('INF')))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7FF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double7">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(xs:double('-INF')))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FFF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double8">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(xs:double('NaN')))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7FF8000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double9">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1, "most-significant-first"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3FF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double10">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1, "big-endian"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3FF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double11">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1, "BE"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3FF0000000000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double12">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1, "least-significant-first"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("000000000000F03F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double13">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1, "little-endian"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("000000000000F03F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double14">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-double(1, "LE"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("000000000000F03F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-double15">
+    <description>Test for the pack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:pack-double(1, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  
+ 
+  
+</test-set>

--- a/bin/pack-float.xml
+++ b/bin/pack-float.xml
@@ -1,0 +1,285 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-pack-float">
+  <description>Tests for the bin:pack-float function</description>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-pack-float-002">
+    <description>pack-float with 0.0 - little endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-float(xs:float(0.0)) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AAAAAA==")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-003">
+    <description>pack-float with +0.0 - big-endian. Note the difference from IEEE regarding no
+        negative zero - in that case the leading octet is 128</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(+xs:float(0.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-004">
+    <description>pack-float with -0.0 - big-endian. Note the difference from IEEE regarding no
+        negative zero - in that case the leading octet is 128</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(-xs:float(0.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(128,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-005">
+    <description>pack-float with 1.0 - little-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(xs:float(1.0),'LE')) </test>
+    <result>
+      <assert-deep-eq>(0,0,128,63)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-006">
+    <description>pack-float with 1.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(xs:float(1.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(63,128,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-007">
+    <description>pack-float with 2.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(xs:float(2.0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(64,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-008">
+    <description>pack-float with positive infinity - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(xs:float(1 div 0e0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,128,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-009">
+    <description>pack-float with negative infinity - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(xs:float(-1 div 0e0),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(255,128,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-float-010">
+    <description>pack-float with NaN - big-endian. Possibilities of other NaN
+        values?</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-float(xs:float(number("NaN")),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,192,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float1">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float2">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3F800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float3">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(-1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("BF800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float4">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(xs:float(-0e0)))</test>
+    <result>
+      <assert-eq>xs:hexBinary("80000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float5">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(xs:float(0e0)))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00000000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float6">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(xs:float('INF')))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7F800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float7">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(xs:float('-INF')))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float8">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(xs:float('NaN')))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7FC00000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float9">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1, "most-significant-first"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3F800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float10">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1, "big-endian"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3F800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float11">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1, "BE"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("3F800000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float12">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1, "least-significant-first"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000803F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float13">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1, "little-endian"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000803F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float14">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-float(1, "LE"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0000803F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-float15">
+    <description>Test for the pack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:pack-float(1, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+ 
+  
+</test-set>

--- a/bin/pack-integer.xml
+++ b/bin/pack-integer.xml
@@ -1,0 +1,635 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-pack-integer">
+  <description>Tests for the bin:pack-integer function</description>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-pack-integer-001">
+    <description>pack-integer with unknown octet-order</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer(0,1,'MOST-sign-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-002">
+    <description>pack-integer octet-order comparison - most significant synonyms</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> for $b in bin:pack-integer(34567,3,'most-significant-first') return $b eq
+                bin:pack-integer(34567,3,'big-endian') and $b eq bin:pack-integer(34567,3,'BE') </test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-003">
+    <description>pack-integer octet-order comparison - least significant synonyms</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> for $b in bin:pack-integer(34567,3,'least-significant-first') return $b eq
+                bin:pack-integer(34567,3,'little-endian') and $b eq bin:pack-integer(34567,3,'LE') </test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-004">
+    <description>pack-integer octet-order comparison - least and most differ</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer(34567,3,'most-significant-first') eq
+                bin:pack-integer(34567,3,'least-significant-first') </test>
+    <result>
+      <assert-false/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-005">
+    <description>pack-integer with negative length</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer(34567,-3,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-006">
+    <description>pack-integer with zero length</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer(34567,0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-007">
+    <description>pack-integer with zero as byte</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer(0,1) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AA==")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-008">
+    <description>pack-integer with non-zero as byte</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer($int.short,1) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("BQ==")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-009">
+    <description>pack-integer with zero as short</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer(0,2) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AAA=")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-010">
+    <description>pack-integer with non-zero as short - default - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer($int.short,2) eq  bin:pack-integer($int.short,2,'BE')</test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-011">
+    <description>pack-integer with non-zero as short - little-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer($int.short,2,'least-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("BQE=")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-012">
+    <description>pack-integer with non-zero as short - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:pack-integer($int.short,2,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AQU=")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-013">
+    <description>pack-integer with non-zero as short - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.short,2)) </test>
+    <result>
+      <assert-deep-eq>(1,5)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-014">
+    <description>pack-integer with non-zero as short - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.short,2,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(1,5)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-015">
+    <description>pack-integer with non-zero as 3-byte - little-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.3,3,'LE')) </test>
+    <result>
+      <assert-deep-eq>(5,1,1)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-016">
+    <description>pack-integer with non-zero as 3-byte - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.3,3,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(1,1,5)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-017">
+    <description>pack-integer with non-zero as int - little-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.int,4,'LE')) </test>
+    <result>
+      <assert-deep-eq>(5,1,1,1)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-018">
+    <description>pack-integer with non-zero as int - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.int,4,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(1,1,1,5)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-019">
+    <description>pack-integer with non-zero as long - little-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.long,8,'LE')) </test>
+    <result>
+      <assert-deep-eq>(5,1,1,1,1,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-020">
+    <description>pack-integer with non-zero as long - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer($int.long,8,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(0,0,0,1,1,1,1,5)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-021">
+    <description>pack-integer with non-zero as BIG - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(12345678901234,12,'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0, 0, 0, 0, 11, 58, 115, 206, 47, 242)</assert-deep-eq>
+    </result>
+  </test-case>
+
+  <test-case name="EXPath-binary-pack-integer-022">
+    <description>pack-integer - negative - big-endian - single-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 1, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(254)</assert-deep-eq>
+    </result>
+  </test-case>
+
+  <test-case name="EXPath-binary-pack-integer-023">
+    <description>pack-integer - negative - big-endian - two-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 2, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(255, 254)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-024">
+    <description>pack-integer - negative - big-endian - four-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 4, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(255, 255, 255, 254)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-025">
+    <description>pack-integer - negative - big-endian - eight-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 8, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(255, 255, 255, 255, 255, 255, 255, 254)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-026">
+    <description>pack-integer - negative - big-endian - 16-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 16, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-027">
+    <description>pack-integer - large negative - big-endian - 16-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-1000000000000, 16, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 23, 43, 90, 240, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-028">
+    <description>pack-integer - negative - big-endian - truncated</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-65536, 1, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-029">
+    <description>pack-integer - negative - big-endian - truncated</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-65536*65536, 3, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-030">
+    <description>pack-integer - negative - little-endian - single-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 1, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(254)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-031">
+    <description>pack-integer - negative - little-endian - 2-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 2, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(254, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-032">
+    <description>pack-integer - negative - little-endian - 4-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 4, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(254, 255, 255, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-033">
+    <description>pack-integer - negative - little-endian - 8-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 8, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(254, 255, 255, 255, 255, 255, 255, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-034">
+    <description>pack-integer - negative - little-endian - 16-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-2, 16, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(254, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-035">
+    <description>pack-integer - large negative - little-endian - 16-byte</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-1000000000000, 16, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(0, 240, 90, 43, 23, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-036">
+    <description>pack-integer - negative - little-endian - truncated</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-65536*65536, 3, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-040">
+    <description>pack-integer - positive - big-endian - truncated</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(65536*65536, 3, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-041">
+    <description>pack-integer - positive - little-endian - truncated</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(65536*65536, 3, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-042">
+    <description>pack-integer - extended zero - big-endian</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(0, 20, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-043">
+    <description>pack-integer - extended zero - little-endian</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(0, 20, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-044">
+    <description>pack-integer - extended -1 - big-endian</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-1, 20, 'BE')) </test>
+    <result>
+      <assert-deep-eq>(255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pack-integer-045">
+    <description>pack-integer - extended zero - little-endian</description>
+    <created by="Michael Kay" on="2022-04-08"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:to-octets(bin:pack-integer(-1, 20, 'LE')) </test>
+    <result>
+      <assert-deep-eq>(255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer1">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer2">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("01")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer3">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0001")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer4">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(9223372036854775807, 8))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7FFFFFFFFFFFFFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer5">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(-1, 8))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FFFFFFFFFFFFFFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer6">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(-1, 9))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FFFFFFFFFFFFFFFFFF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer7">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2, "most-significant-first"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0001")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer8">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2, "big-endian"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0001")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer9">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2, "BE"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0001")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer10">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2, "least-significant-first"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0100")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer11">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2, "little-endian"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0100")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer12">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:pack-integer(1, 2, "LE"))</test>
+    <result>
+      <assert-eq>xs:hexBinary("0100")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer13">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:pack-integer(1, -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pack-integer14">
+    <description>Test for the pack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:pack-integer(1, 1, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+
+  
+ 
+  
+</test-set>

--- a/bin/pad-left.xml
+++ b/bin/pad-left.xml
@@ -1,0 +1,166 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-pad-left">
+  <description>Tests for the bin:pad-left function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+ 
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-pad-left-001">
+    <description>Pad left on an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left((),2) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-002">
+    <description>Pad-left with negative size</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left($man.base,-1) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-003">
+    <description>Pad-left with negative octet</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left($man.base,1,-3) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-004">
+    <description>Pad-left with large octet</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left($man.base,1,333) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-005">
+    <description>Pad-left with zero size</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left($man.base,0) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-string-value>TWFu</assert-string-value>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-006">
+    <description>Pad-left by 3 octets</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left($man.base,3) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AAAATWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-007">
+    <description>Pad-left by 1 octet</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-left($man.base,1) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("AE1hbg==")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-left-008">
+    <description>Pad-left by 1 octet with non-zero padding</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:to-octets(bin:pad-left($man.base,1,12)) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer*</assert-type>
+        <assert-deep-eq>(12,77,97,110)</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-left1">
+    <description>Test for the pad-left function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:pad-left(xs:base64Binary(xs:hexBinary("")), 1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-left2">
+    <description>Test for the pad-left function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:pad-left(xs:base64Binary(xs:hexBinary("")), 1, 255))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-left3">
+    <description>Test for the pad-left function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:pad-left(xs:base64Binary(xs:hexBinary("01")), 2, 127))</test>
+    <result>
+      <assert-eq>xs:hexBinary("7F7F01")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-left4">
+    <description>Test for the pad-left function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:pad-left(xs:base64Binary(xs:hexBinary("")), -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-left5">
+    <description>Test for the pad-left function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:pad-left(xs:base64Binary(xs:hexBinary("")), 0, 256)</test>
+    <result>
+     <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/pad-right.xml
+++ b/bin/pad-right.xml
@@ -1,0 +1,166 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-pad-right">
+  <description>Tests for the bin:pad-right function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-pad-right-001">
+    <description>Pad right on an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right((),2) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-002">
+    <description>Pad-right with negative size</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right($man.base,-1) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-003">
+    <description>Pad-right with negative octet</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right($man.base,1,-3) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-004">
+    <description>Pad-right with large octet</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right($man.base,1,333) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-005">
+    <description>Pad-right with zero size</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right($man.base,0) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFu")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-006">
+    <description>Pad-right by 3 octets</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right($man.base,3) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFuAAAA")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-007">
+    <description>Pad-right by 1 octet</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:pad-right($man.base,1) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary("TWFuAA==")</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-pad-right-008">
+    <description>Pad-right by 1 octet with non-zero padding</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:to-octets(bin:pad-right($man.base,1,12)) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer*</assert-type>
+        <assert-deep-eq>(77,97,110,12)</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-right1">
+    <description>Test for the pad-right function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:pad-right(xs:base64Binary(xs:hexBinary("")), 1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-right2">
+    <description>Test for the pad-right function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:pad-right(xs:base64Binary(xs:hexBinary("")), 1, 255))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-right3">
+    <description>Test for the pad-right function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:pad-right(xs:base64Binary(xs:hexBinary("01")), 2, 127))</test>
+    <result>
+      <assert-eq>xs:hexBinary("017F7F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-right4">
+    <description>Test for the pad-right function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:pad-right(xs:base64Binary(xs:hexBinary("")), -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-pad-right5">
+    <description>Test for the pad-right function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:pad-right(xs:base64Binary(xs:hexBinary("")), 0, 256)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}octet-out-of-range"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/part.xml
+++ b/bin/part.xml
@@ -1,0 +1,170 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-part">
+  <description>Tests for the bin:part function</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+ <test-case name="EXPath-binary-part-001">
+    <description>Part of an empty sequence</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:part((),0) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-part-002">
+    <description>Part with negative offset</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:part($man.base,-1) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-part-003">
+    <description>Part with negative size</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:part($man.base,0,-1) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-part-004">
+    <description>Part: offset just at end of input</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:part($man.base,3) </test>
+    <result>
+      <assert-eq>xs:base64Binary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-part-005">
+    <description>Part: offset beyond end of input</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:part($man.base,4) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-part-006">
+    <description>Part: end beyond end of input</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:part($man.base,2,2) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part1">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:part((), 0))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part2">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:part(xs:base64Binary(xs:hexBinary("FF")), 0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part3">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:part(xs:base64Binary(xs:hexBinary("FF")), 0, 1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part4">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:part(xs:base64Binary(xs:hexBinary("FF")), 1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part5">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>xs:hexBinary(bin:part(xs:base64Binary(xs:hexBinary("FF")), 1, 0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part6">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:part(xs:base64Binary(xs:hexBinary("FF")), -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part7">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:part(xs:base64Binary(xs:hexBinary("FF")), 0, -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part8">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:part(xs:base64Binary(xs:hexBinary("FF")), 2)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-part9">
+    <description>Test for the part function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:part(xs:base64Binary(xs:hexBinary("FF")), 0, 2)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+</test-set>

--- a/bin/shift.xml
+++ b/bin/shift.xml
@@ -1,0 +1,255 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-shift">
+  <description>Tests for the bin:shift function</description>
+  
+  <environment name="EXPath-binary-bitwise">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
+    <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>
+    <param name="c" select="xs:base64Binary(xs:hexBinary('0FABCD'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-bitwise-shift-001">
+    <description>bitwise-shift on empty sequence</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:shift((),5) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-002">
+    <description>bitwise-shift by 0 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:shift($a,0) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary("F00F"))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-003">
+    <description>bitwise-shift left by 1 bit</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,1)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("E01E")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-004">
+    <description>bitwise-shift left by 4 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,4)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("00F0")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-005">
+    <description>bitwise-shift left by 8 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,8)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0F00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-006">
+    <description>bitwise-shift left by 9 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,9)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("1E00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-007">
+    <description>bitwise-shift left by 12 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,12)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("F000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-008">
+    <description>bitwise-shift left by 16 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,16)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-009">
+    <description>bitwise-shift left by 17 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,17)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-010">
+    <description>bitwise-shift right by 1 bit</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-1)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("7807")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-011">
+    <description>bitwise-shift right by 4 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-4)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0F00")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-012">
+    <description>bitwise-shift right by 8 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-8)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("00F0")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-013">
+    <description>bitwise-shift right by 9 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-9)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0078")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-014">
+    <description>bitwise-shift right by 12 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-12)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("000F")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-015">
+    <description>bitwise-shift right by 16 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-16)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-shift-016">
+    <description>bitwise-shift right by 17 bits</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> xs:hexBinary(bin:shift($a,-17)) </test>
+    <result>
+
+      <assert-eq>xs:hexBinary("0000")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-shift1">
+    <description>Test for the shift function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:shift((), 1))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-shift2">
+    <description>Test for the shift function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:shift(xs:base64Binary(xs:hexBinary("77")), 0))</test>
+    <result>
+      <assert-eq>xs:hexBinary("77")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-shift3">
+    <description>Test for the shift function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:shift(xs:base64Binary(xs:hexBinary("33")), 1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("66")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-shift4">
+    <description>Test for the shift function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:shift(xs:base64Binary(xs:hexBinary("66")), -1))</test>
+    <result>
+      <assert-eq>xs:hexBinary("33")</assert-eq>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/to-octets.xml
+++ b/bin/to-octets.xml
@@ -1,0 +1,81 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-to-octets">
+  <description>Tests for the bin:to-octets unction</description>
+  
+  <environment name="EXPath-binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <!-- 'Man' in base64 - 3 octets, 4 characters -->
+    <param name="man.base" select="xs:base64Binary('TWFu')"/>
+    <param name="man.octets" select="77,97,110"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-to-octets-001">
+    <description>Octets from a zero-length binary</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:to-octets(xs:base64Binary("")) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-to-octets-002">
+    <description>Generate octets from a 4-length</description>
+    <created by="John Lumley" on="2013-07-18"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary"/>
+    <test> bin:to-octets($man.base) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer*</assert-type>
+        <assert-deep-eq>(77,97,110)</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-to-octets1">
+    <description>Test for the to-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:to-octets(xs:base64Binary(xs:hexBinary("")))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-to-octets2">
+    <description>Test for the to-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:to-octets(xs:base64Binary(xs:hexBinary("00")))</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-to-octets3">
+    <description>Test for the to-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:to-octets(xs:base64Binary(xs:hexBinary("FF")))</test>
+    <result>
+      <assert-eq>255</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-to-octets4">
+    <description>Test for the to-octets function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="EXPath-binary"/>
+    <test>bin:to-octets(xs:base64Binary(xs:hexBinary("1122")))</test>
+    <result>
+      <assert-deep-eq>17, 34</assert-deep-eq>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/unpack-double.xml
+++ b/bin/unpack-double.xml
@@ -1,0 +1,326 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-unpack-double">
+  <description>Tests for the bin:unpack-double function</description>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-unpack-double-001">
+    <description>unpack-double with unknown octet-order</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-double(bin:from-octets($double.1.octets),0,'MOST-sign-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-002">
+    <description>unpack-double with negative offset</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-double(bin:from-octets($double.1.octets),-1,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-003">
+    <description>unpack-double extending beyond data</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-double(bin:from-octets($double.1.octets),1,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-004">
+    <description>unpack-double for -0.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-double($double.negative.0,0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:double</assert-type>
+        <assert-eq>-0.0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-005">
+    <description>unpack-double for 1.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-double(bin:from-octets($double.1.octets),0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:double</assert-type>
+        <assert-eq>1.0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-006">
+    <description>unpack-double with NaN - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-double(bin:from-octets((127,248,0,0,0,0,0,0)),0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:double</assert-type>
+        <assert-deep-eq>number("NaN")</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-007">
+    <description>unpack-double with NaN with payload - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-double(bin:from-octets((127,248,0,0,0,0,0,1)),0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:double</assert-type>
+        <assert-deep-eq>number("NaN")</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-008">
+    <description>unpack-double with quiet NaN with payload - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:to-octets(bin:pack-double(bin:unpack-double(bin:from-octets((127,248,0,0,0,0,0,1)),0,'most-significant-first'),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,248,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-double-009">
+    <description>unpack-double with signalling NaN with payload - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:to-octets(bin:pack-double(bin:unpack-double(bin:from-octets((127,240,0,0,0,0,0,1)),0,'most-significant-first'),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,248,0,0,0,0,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double1">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("0000000000000000")), 0)</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double2">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("3FF0000000000000")), 0)</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double3">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("BFF0000000000000")), 0)</test>
+    <result>
+      <assert-eq>-1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double4">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("8000000000000000")), 0)</test>
+    <result>
+      <assert-eq>-0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double5">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("0000000000000000")), 0)</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double6">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("7FF0000000000000")), 0)</test>
+    <result>
+      <assert-eq>1 div 0e0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double7">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("FFF0000000000000")), 0)</test>
+    <result>
+      <assert-eq>-1 div 0e0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double8">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("7FF8000000000000")), 0)</test>
+    <result>
+      <assert-deep-eq>number("NaN")</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double9">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("3FF0000000000000")), 0, "most-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double10">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("3FF0000000000000")), 0, "big-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double11">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("3FF0000000000000")), 0, "BE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double12">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("000000000000F03F")), 0, "least-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double13">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("000000000000F03F")), 0, "little-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double14">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("000000000000F03F")), 0, "LE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double15">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("0000000000000000")), -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double16">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("0000000000000000")), 1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double17">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("00")), 0)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-double18">
+    <description>Test for the unpack-double function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-double(xs:base64Binary(xs:hexBinary("0000000000000000")), 0, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/unpack-float.xml
+++ b/bin/unpack-float.xml
@@ -1,0 +1,323 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-unpack-float">
+  <description>Tests for the bin:unpack-float function</description>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-unpack-float-001">
+    <description>unpack-float with unknown octet-order</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float(bin:from-octets($float.1.octets),0,'MOST-sign-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-002">
+    <description>unpack-float with negative offset</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float(bin:from-octets($float.1.octets),-1,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-003">
+    <description>unpack-float extending beyond data</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float(bin:from-octets($float.1.octets),1,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-004">
+    <description>unpack-float for -0.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float($float.negative.0,0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:float</assert-type>
+        <assert-eq>-0.0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-005">
+    <description>unpack-float for 1.0 - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float(bin:from-octets($float.1.octets),0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:float</assert-type>
+        <assert-eq>1.0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-006">
+    <description>unpack-float with NaN - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float(bin:from-octets((127,192,0,0)),0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:float</assert-type>
+        <assert-deep-eq>xs:float(number("NaN"))</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-007">
+    <description>unpack-float with NaN with payload - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-float(bin:from-octets((127,192,0,1)),0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:float</assert-type>
+        <assert-deep-eq>number("NaN")</assert-deep-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-008">
+    <description>unpack-float with quiet NaN with payload - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:to-octets(bin:pack-float(bin:unpack-float(bin:from-octets((127,192,0,1)),0,'most-significant-first'),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,192,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-float-009">
+    <description>unpack-float with signalling NaN with payload - big-endian</description>
+    <created by="John Lumley" on="2013-07-19"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:to-octets(bin:pack-float(bin:unpack-float(bin:from-octets((127,248,0,1)),0,'most-significant-first'),'most-significant-first')) </test>
+    <result>
+      <assert-deep-eq>(127,192,0,0)</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float1">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("00000000")), 0)</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float2">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("3F800000")), 0)</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float3">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("BF800000")), 0)</test>
+    <result>
+      <assert-eq>-1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float4">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("80000000")), 0)</test>
+    <result>
+      <assert-eq>-0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float5">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("00000000")), 0)</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float6">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("7F800000")), 0)</test>
+    <result>
+      <assert-eq>1 div 0e0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float7">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("FF800000")), 0)</test>
+    <result>
+      <assert-eq>-1 div 0e0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float8">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("7FC00000")), 0)</test>
+    <result>
+      <assert-deep-eq>number("NaN")</assert-deep-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float9">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("3F800000")), 0, "most-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float10">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("3F800000")), 0, "big-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float11">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("3F800000")), 0, "BE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float12">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("0000803F")), 0, "least-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float13">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("0000803F")), 0, "little-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float14">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("0000803F")), 0, "LE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float15">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("00000000")), -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float16">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("00000000")), 1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float17">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("00")), 0)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-float18">
+    <description>Test for the unpack-float function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-float(xs:base64Binary(xs:hexBinary("00000000")), 0, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+ 
+  
+</test-set>

--- a/bin/unpack-integer.xml
+++ b/bin/unpack-integer.xml
@@ -1,0 +1,449 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-unpack-integer">
+  <description>Tests for the bin:unpack-integer function</description>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-unpack-integer-001">
+    <description>unpack-integer with unknown octet-order</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.byte.B,0,1,'MOST-sign-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-002">
+    <description>unpack-integer octet-order comparison - most significant synonyms</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> for $b in bin:unpack-integer($int.short.B,0,2,'most-significant-first')
+                return $b eq bin:unpack-integer($int.short.B,0,2,'big-endian') and $b eq
+                bin:unpack-integer($int.short.B,0,2,'BE') </test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-003">
+    <description>unpack-integer octet-order comparison - least significant synonyms</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> for $b in bin:unpack-integer($int.short.B,0,2,'least-significant-first')
+                return $b eq bin:unpack-integer($int.short.B,0,2,'little-endian') and $b eq
+                bin:unpack-integer($int.short.B,0,2,'LE') </test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-004">
+    <description>unpack-integer octet-order comparison - least and most differ</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B,0,2,'most-significant-first') eq
+                bin:unpack-integer($int.short.B,0,2,'least-significant-first') </test>
+    <result>
+      <assert-false/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-005">
+    <description>unpack-integer with negative offset</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B,-1,2,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-006">
+    <description>unpack-integer with negative length</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B,0,-2,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-007">
+    <description>unpack-integer extending beyond data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B,1,2,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-008">
+    <description>unpack-integer with zero length </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.byte.B,0,0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-009">
+    <description>unpack-integer on byte </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.byte.B,0,1,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>-16</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-010">
+    <description>unpack-integer on short </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B-1,0,2,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>-1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-011">
+    <description>unpack-integer on short </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-integer(xs:base64Binary(xs:hexBinary('0001')),0,2,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-012">
+    <description>unpack-integer on short </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B,0,2,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>-4032</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-013">
+    <description>unpack-integer on short </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-integer($int.short.B-1,0,2,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>-1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-014">
+    <description>unpack-integer on long </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-integer(xs:base64Binary(xs:hexBinary('0000000000000001')),0,8,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-015">
+    <description>unpack-integer on long </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-integer(xs:base64Binary(xs:hexBinary('ffffffffffffffff')),0,8,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>-1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-016">
+    <description>unpack unsigned integer, BE, 2 octets</description>
+    <created by="Michael Kay after Olivier Xillo" on="2022-09-18"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+      bin:unpack-unsigned-integer(bin:hex('8008'),0,2,'BE')
+    </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>32776</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-017">
+    <description>unpack unsigned integer, LE, 2 octets</description>
+    <created by="Michael Kay after Olivier Xillo" on="2022-09-18"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+      bin:unpack-unsigned-integer(bin:hex('8008'),0,2,'LE')
+    </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>2176</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-018">
+    <description>unpack signed integer, BE, 2 octets</description>
+    <created by="Michael Kay after Olivier Xillo" on="2022-09-18"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+      bin:unpack-integer(bin:hex('8008'),0,2,'BE')
+    </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>-32760</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-integer-019">
+    <description>unpack signed integer, LE, 2 octets (Saxon bug 5690)</description>
+    <created by="Michael Kay after Olivier Xillo" on="2022-09-18"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+      bin:unpack-integer(bin:hex('8008'),0,2,'LE')
+    </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>2176</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer1">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("01")), 0, 0)</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer2">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("01")), 0, 1)</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer3">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("FF")), 0, 1)</test>
+    <result>
+      <assert-eq>-1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer4">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2)</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer5">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("7FFF")), 0, 2)</test>
+    <result>
+      <assert-eq>32767</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer6">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("FFFF")), 0, 2)</test>
+    <result>
+      <assert-eq>-1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer7">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2, "most-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer8">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2, "big-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer9">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2, "BE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer10">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0100")), 0, 2, "least-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer11">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0100")), 0, 2, "little-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer12">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("0100")), 0, 2, "LE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer13">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("00")), -1, 0)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer14">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("00")), 0, -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer15">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("00")), 0, 2)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-integer16">
+    <description>Test for the unpack-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-integer(xs:base64Binary(xs:hexBinary("00")), 0, 0, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+
+  
+ 
+  
+</test-set>

--- a/bin/unpack-unsigned-integer.xml
+++ b/bin/unpack-unsigned-integer.xml
@@ -1,0 +1,422 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-unpack-unsigned-integer">
+  <description>Tests for the bin:unpack-unsigned-integer function</description>
+  
+  <environment name="EXPath-binary.numeric">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="int.byte" select="5"/>
+    <param name="int.short" select="256 * 1 + 5"/>
+    <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.int" select="16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="int.long" select="4294967296 * 1 + 16777216 * 1 + 65536 * 1 + 256 * 1 + 5"/>
+    <param name="double.negative.0" select="xs:base64Binary(xs:hexBinary('8000000000000000'))"/>
+    <param name="double.1" select="xs:base64Binary(xs:hexBinary('3ff0000000000000'))"/>
+    <param name="double.1.octets" select="(63,240,0,0,0,0,0,0)"/>
+    <param name="float.negative.0" select="xs:base64Binary(xs:hexBinary('80000000'))"/>
+    <param name="float.1.octets" select="(63,128,0,0)"/>
+    <param name="int.byte.B" select="xs:base64Binary(xs:hexBinary('f0'))"/>
+    <param name="int.short.B" select="xs:base64Binary(xs:hexBinary('f040'))"/>
+    <param name="int.short.B-1" select="xs:base64Binary(xs:hexBinary('ffff'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-001">
+    <description>unpack-unsigned-integer with unknown octet-order</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.byte.B,0,1,'MOST-sign-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-002">
+    <description>unpack-unsigned-integer octet-order comparison - most significant
+        synonyms</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> for $b in bin:unpack-unsigned-integer($int.short.B,0,2,'most-significant-first')
+                return $b eq bin:unpack-unsigned-integer($int.short.B,0,2,'big-endian') and $b eq
+                bin:unpack-unsigned-integer($int.short.B,0,2,'BE') </test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-003">
+    <description>unpack-unsigned-integer octet-order comparison - least significant
+        synonyms</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> for $b in bin:unpack-unsigned-integer($int.short.B,0,2,'least-significant-first')
+                return $b eq bin:unpack-unsigned-integer($int.short.B,0,2,'little-endian') and $b eq
+                bin:unpack-unsigned-integer($int.short.B,0,2,'LE') </test>
+    <result>
+      <assert-true/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-004">
+    <description>unpack-unsigned-integer octet-order comparison - least and most
+        differ</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.short.B,0,2,'most-significant-first') eq
+                bin:unpack-unsigned-integer($int.short.B,0,2,'least-significant-first') </test>
+    <result>
+      <assert-false/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-005">
+    <description>unpack-unsigned-integer with negative offset</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.short.B,-1,2,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-006">
+    <description>unpack-unsigned-integer with negative length</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.short.B,0,-2,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-007">
+    <description>unpack-unsigned-integer extending beyond data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.short.B,1,2,'most-significant-first') </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-008">
+    <description>unpack-unsigned-integer with zero length </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.byte.B,0,0,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>0</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-009">
+    <description>unpack-unsigned-integer on byte </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.byte.B,0,1,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>240</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-010">
+    <description>unpack-unsigned-integer on short </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test> bin:unpack-unsigned-integer($int.short.B,0,2,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>61504</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-011">
+    <description>unpack-unsigned-integer on long </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary('0000000000000001')),0,8,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>1</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-012">
+    <description>unpack-unsigned-integer on long </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <modified by="Michael Kay" on="2021-05-10"
+      change="fix bug https://github.com/expath/expath-cg/issues/116"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <test>
+                bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary('ffffffffffffffff')),0,8,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>18446744073709551615</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-013">
+    <description>unpack-unsigned-integer on BIG </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <dependency type="limits" value="big_integer" satisfied="true"/>
+    <test>
+                bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary('0fffffffffffffffffff')),0,10,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>75557863725914323419135</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-unpack-unsigned-integer-014">
+    <description>unpack-unsigned-integer on BIG </description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary.numeric"/>
+    <dependency type="limits" value="big_integer" satisfied="true"/>
+    <test>
+                bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary('ffffffffffffffffffff')),0,10,'most-significant-first') </test>
+    <result>
+      <all-of>
+        <assert-type>xs:integer</assert-type>
+        <assert-eq>1208925819614629174706175</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer1">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("01")), 0, 0)</test>
+    <result>
+      <assert-eq>0</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer2">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("01")), 0, 1)</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer3">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("FF")), 0, 1)</test>
+    <result>
+      <assert-eq>255</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer4">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2)</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer5">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("7FFF")), 0, 2)</test>
+    <result>
+      <assert-eq>32767</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer6">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("FFFF")), 0, 2)</test>
+    <result>
+      <assert-eq>65535</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer7">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("FFFFFFFF")), 0, 4)</test>
+    <result>
+      <assert-eq>4294967295</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer8">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("01FFFFFFFF")), 0, 5)</test>
+    <result>
+      <assert-eq>8589934591</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer9">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("FFFFFFFFFF")), 0, 5)</test>
+    <result>
+      <assert-eq>1099511627775</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer10">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("FFFFFFFFFFFF")), 0, 6)</test>
+    <result>
+      <assert-eq>281474976710655</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer11">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2, "most-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer12">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2, "big-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer13">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0001")), 0, 2, "BE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer14">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0100")), 0, 2, "least-significant-first")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer15">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0100")), 0, 2, "little-endian")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer16">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("0100")), 0, 2, "LE")</test>
+    <result>
+      <assert-eq>1</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer17">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("00")), -1, 0)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer18">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("00")), 0, -1)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}negative-size"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer19">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("00")), 0, 2)</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}index-out-of-range"/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-unpack-unsigned-integer20">
+    <description>Test for the unpack-unsigned-integer function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:unpack-unsigned-integer(xs:base64Binary(xs:hexBinary("00")), 0, 0, "X")</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}unknown-significance-order"/>
+    </result>
+  </test-case>
+  
+ 
+  
+</test-set>

--- a/bin/xor.xml
+++ b/bin/xor.xml
@@ -1,0 +1,155 @@
+<test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="bin-xor">
+  <description>Tests for the bin:xor function</description>
+  
+  <environment name="EXPath-binary-bitwise">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
+    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <param name="empty.bin" select="xs:base64Binary('')"/>
+    <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
+    <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>
+    <param name="c" select="xs:base64Binary(xs:hexBinary('0FABCD'))"/>
+  </environment>
+  
+  <environment name="binary">
+    <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
+  </environment>
+  
+  <dependency type="feature" value="binary"/>
+  
+  <test-case name="EXPath-binary-bitwise-xor-001">
+    <description>bitwise-xor with differing lengths</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:xor($a,$c) </test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-xor-002">
+    <description>bitwise-xor on empty sequences</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:xor((),()) </test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-xor-003">
+    <description>bitwise-xor with data and empty sequence</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2013-11-13" change="change to empty sequence result"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:xor($a,()) </test>
+    <result>
+      <assert-empty/>
+      <!--<error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>-->
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-xor-004">
+    <description>bitwise-xor with empty sequence and data</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2013-11-13" change="change to empty sequence result"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:xor((),$a) </test>
+    <result>
+      <assert-empty/>
+      <!--<error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>-->
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-xor-005">
+    <description>bitwise-xor on empty binaries</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:xor($empty.bin,$empty.bin) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary('')</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="EXPath-binary-bitwise-xor-006">
+    <description>bitwise-xor with similar lengths</description>
+    <created by="John Lumley" on="2013-07-22"/>
+    <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <environment ref="EXPath-binary-bitwise"/>
+    <test> bin:xor($a,$b) </test>
+    <result>
+      <all-of>
+        <assert-type>xs:base64Binary</assert-type>
+        <assert-eq>xs:base64Binary(xs:hexBinary("FFFF"))</assert-eq>
+      </all-of>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-xor1">
+    <description>Test for the xor function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:xor((), xs:base64Binary(xs:hexBinary("00"))))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-xor2">
+    <description>Test for the xor function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:xor(xs:base64Binary(xs:hexBinary("00")), ()))</test>
+    <result>
+      <assert-empty/>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-xor3">
+    <description>Test for the xor function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:xor(xs:base64Binary(xs:hexBinary("")), xs:base64Binary(xs:hexBinary(""))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-xor4">
+    <description>Test for the xor function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:xor(xs:base64Binary(xs:hexBinary("80")), xs:base64Binary(xs:hexBinary("7F"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("FF")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-xor5">
+    <description>Test for the xor function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>xs:hexBinary(bin:xor(xs:base64Binary(xs:hexBinary("1234")), xs:base64Binary(xs:hexBinary("4321"))))</test>
+    <result>
+      <assert-eq>xs:hexBinary("5115")</assert-eq>
+    </result>
+  </test-case>
+  
+  <test-case name="bin-xor6">
+    <description>Test for the xor function.</description>
+    <created by="Christian Grün" on="2013-11-19+01:00"/>
+    <environment ref="binary"/>
+    <test>bin:xor(xs:base64Binary(xs:hexBinary("00")), xs:base64Binary(xs:hexBinary("")))</test>
+    <result>
+      <error code="Q{http://expath.org/ns/binary}differing-length-arguments"/>
+    </result>
+  </test-case>
+ 
+  
+</test-set>

--- a/catalog.xml
+++ b/catalog.xml
@@ -737,6 +737,35 @@
    <test-set name="app-XMark"                           file="app/XMark.xml"/>
    <test-set name="app-spec-examples"                   file="app/fo-spec-examples.xml"/>
     
+   <!-- EXPath BINARY -->
+    
+    <test-set name="bin-and"                             file="bin/and.xml"/> 
+    <test-set name="bin-bin"                             file="bin/bin.xml"/> 
+    <test-set name="bin-decode-string"                   file="bin/decode-string.xml"/> 
+    <test-set name="bin-encode-string"                   file="bin/encode-string.xml"/> 
+    <test-set name="bin-find"                            file="bin/find.xml"/> 
+    <test-set name="bin-from-octets"                     file="bin/from-octets.xml"/> 
+    <test-set name="bin-hex"                             file="bin/hex.xml"/> 
+    <test-set name="bin-insert-before"                   file="bin/insert-before.xml"/> 
+    <test-set name="bin-join"                            file="bin/join.xml"/> 
+    <test-set name="bin-length"                          file="bin/length.xml"/> 
+    <test-set name="bin-not"                             file="bin/not.xml"/> 
+    <test-set name="bin-octal"                           file="bin/octal.xml"/> 
+    <test-set name="bin-or"                              file="bin/or.xml"/> 
+    <test-set name="bin-pack-double"                     file="bin/pack-double.xml"/> 
+    <test-set name="bin-pack-float"                      file="bin/pack-float.xml"/> 
+    <test-set name="bin-pack-integer"                    file="bin/pack-integer.xml"/> 
+    <test-set name="bin-pad-left"                        file="bin/pad-left.xml"/> 
+    <test-set name="bin-pad-right"                       file="bin/pad-right.xml"/> 
+    <test-set name="bin-part"                            file="bin/part.xml"/> 
+    <test-set name="bin-shift"                           file="bin/shift.xml"/> 
+    <test-set name="bin-to-octets"                       file="bin/to-octets.xml"/> 
+    <test-set name="bin-unpack-double"                   file="bin/unpack-double.xml"/> 
+    <test-set name="bin-unpack-float"                    file="bin/unpack-float.xml"/> 
+    <test-set name="bin-unpack-integer"                  file="bin/unpack-integer.xml"/> 
+    <test-set name="bin-unpack-unsigned-integer"         file="bin/unpack-unsigned-integer.xml"/>
+    <test-set name="bin-xor"                             file="bin/xor.xml"/> 
+    
     <!-- XQUERY UPDATE -->
     
     <test-set name="upd-VariableDeclaration"            file="upd/VariableDeclaration.xml"/>

--- a/map/build.xml
+++ b/map/build.xml
@@ -445,7 +445,7 @@
         </result>
     </test-case>
     
-    <test-case name="map-build-121" covers-40="PR1703">
+    <test-case name="map-build-122" covers-40="PR1703">
         <description>Order is retained</description>
         <created by="Michael Kay, Saxonica" on="2025-01-22"/>
         <environment ref="map"/>
@@ -458,7 +458,7 @@
         </result>
     </test-case>
     
-    <test-case name="map-build-122" covers-40="PR1041">
+    <test-case name="map-build-123" covers-40="PR1041">
         <description>Test equivalence of another implementation given in spec</description>
         <created by="Michael Kay" on="2025-01-29"/>
         <test>let $m := map:build(tokenize("The cat sat on the mat"), characters#1, upper-case#1, 

--- a/map/of-pairs.xml
+++ b/map/of-pairs.xml
@@ -362,7 +362,7 @@
     
     <test-case name="map-of-pairs-907">
         <description>Can't have both combine and duplicates</description>
-        <created by="Michael Kay, Saxonica" on="205-01-29"/>
+        <created by="Michael Kay, Saxonica" on="2025-01-29"/>
         <environment ref="map"/>
         <test><![CDATA[map:of-pairs(map:pairs({'a':1}),
             {'duplicates':'use-last', 'combine':concat#2})]]></test>

--- a/results/sandpit/put-001.xml
+++ b/results/sandpit/put-001.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><test it="now"/>

--- a/results/sandpit/put-009.xml
+++ b/results/sandpit/put-009.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><test/>

--- a/results/sandpit/put-013a.xml
+++ b/results/sandpit/put-013a.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><test-a/>

--- a/results/sandpit/put-013b.xml
+++ b/results/sandpit/put-013b.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><test-b/>

--- a/results/sandpit/put-101.xml
+++ b/results/sandpit/put-101.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><test it="2025-02-02Z"/>


### PR DESCRIPTION
Integrates the tests from the two EXPath binary test collections into the QT4 test suite, with one test set per function. At this stage there are no test changes to account for the spec changes proposed in spec PR [1753]([](https://github.com/qt4cg/qtspecs/pull/1753))