### PR TITLE
Change tests asking for parser success/failure where it should be failure/success 

### DIFF
--- a/fn/sort-with.xml
+++ b/fn/sort-with.xml
@@ -220,10 +220,11 @@ sort-with(
   <test-case name="sort-with-018">
     <description>Sort nodes</description>
     <created by="Michael Kay" on="2024-03-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-18" change="change 'if' syntax from braced to unbraced"/>
     <test><![CDATA[
       let $doc1 := parse-xml("<doc><a>1</a><a>2</a><a>3</a></doc>")
       let $doc2 := parse-xml("<cod><a>4</a><a>5</a><a>6</a></cod>")
-      let $doc-order := fn($x, $y) {if ($x is $y) {0} else if ($x << $y) {-1} else {+1}}
+      let $doc-order := fn($x, $y) {if ($x is $y) then 0 else if ($x << $y) then -1 else +1}
       let $root-name := fn($x){local-name($x/ancestor::*[last()])}     
       return sort-with(($doc1//a, $doc2//a), 
                        (fn($x,$y){compare($root-name($x), $root-name($y))}, $doc-order))

--- a/prod/CompElemConstructor.xml
+++ b/prod/CompElemConstructor.xml
@@ -802,10 +802,14 @@
    <test-case name="K2-ComputeConElem-20" covers-40="PR1480">
       <description> Disallow reserved names </description>
       <created by="Michael Kay" on="2024-06-11"/>
+      <modified by="Gunther Rademacher" on="2025-02-18" change="replace error codes - this is not a syntax error XPST0003"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[element div {}]]></test>
       <result>
-         <error code="XPST0003"/>
+         <any-of>
+            <error code="XPDY0002"/>
+            <error code="FOTY0013"/>
+         </any-of>   
       </result>
    </test-case>
    


### PR DESCRIPTION
This change fixes two test cases:

- `sort-with-018`: this was using the braced-if syntax, and it is changed to unbraced
- `K2-ComputeConElem-20`: this asked for a parsing error `XPST0003` for the statement `element div {}`, based on the idea that `div` is not allowed as an unqualified element name. However this parses successfully as a `div` operator with a name on the left hand side and a map constructor on the right hand side. This may not be a valid division expression, but the grammar allows it to be parsed this way, so the test should not expect a parsing error. The expectation is replaced by the error codes that Saxon and BaseX come up with for expressions that try to divide by an empty map.