### PR TITLE
Add quotes that become necessary to meet constraint 'unreserved name'

### DIFF
--- a/prod/CompNamespaceConstructor/cnc-module.xq
+++ b/prod/CompNamespaceConstructor/cnc-module.xq
@@ -16,7 +16,7 @@ declare function mod1:nested() as element() {
   element outer { 
     namespace out { "http://out.zorba-xquery.com/" },
     element inner {
-      namespace in { "http://in.zorba-xquery.com/" }
+      namespace "in" { "http://in.zorba-xquery.com/" }
     } 
   }
 };


### PR DESCRIPTION
This change adds quotes around `in` in

```xquery
namespace in { "http://in.zorba-xquery.com/" }
```

because `in` is no longer allowed as a plain name per constraint "unreserved name" in computed node constructors.