### PR TITLE
Add missing `typedData` dependencies to some tests for `fn:atomic-type-annotation` and `fn:node-type-annotation`

### DIFF
--- a/fn/atomic-type-annotation.xml
+++ b/fn/atomic-type-annotation.xml
@@ -87,7 +87,9 @@
   <test-case name="atomic-type-annotation-100">
     <description>node validated against type xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>atomic-type-annotation(//*:a)</test>
     <result>
       <all-of>
@@ -107,7 +109,9 @@
   <test-case name="atomic-type-annotation-101">
     <description>node validated against type derived from xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>atomic-type-annotation(//*:b)</test>
     <result>
       <all-of>
@@ -125,7 +129,9 @@
   <test-case name="atomic-type-annotation-102">
     <description>node validated against anonymous type derived from xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>atomic-type-annotation(//*:c)</test>
     <result>
       <all-of>
@@ -143,7 +149,9 @@
   <test-case name="atomic-type-annotation-103">
     <description>node validated against anonymous type derived from a restriction of xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>atomic-type-annotation(//*:d)</test>
     <result>
       <all-of>

--- a/fn/node-type-annotation.xml
+++ b/fn/node-type-annotation.xml
@@ -55,7 +55,9 @@
   <test-case name="node-type-annotation-100">
     <description>node validated against type xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>node-type-annotation(//*:a)</test>
     <result>
       <all-of>
@@ -75,7 +77,9 @@
   <test-case name="node-type-annotation-101">
     <description>node validated against type derived from xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>node-type-annotation(//*:b)</test>
     <result>
       <all-of>
@@ -93,7 +97,9 @@
   <test-case name="node-type-annotation-102">
     <description>node validated against anonymous type derived from xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>node-type-annotation(//*:c)</test>
     <result>
       <all-of>
@@ -111,7 +117,9 @@
   <test-case name="node-type-annotation-103">
     <description>node validated against anonymous type derived from a restriction of xs:integer</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-02-25" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>atomic-type-annotation(//*:d)</test>
     <result>
       <all-of>


### PR DESCRIPTION
Some tests for `fn:atomic-type-annotation` and `fn:node-type-annotation` require typed data, but are not marked with a `typedData` dependency. 

This change adds the missing dependencies.