### PR TITLE
Add missing `typedData` dependency

### DIFF
--- a/fn/node-type-annotation.xml
+++ b/fn/node-type-annotation.xml
@@ -139,7 +139,9 @@
   <test-case name="node-type-annotation-104">
     <description>node validated against complex anonymous type</description>
     <created by="Michael Kay" on="2024-12-02"/>
+    <modified by="Gunther Rademacher" on="2025-02-26" change="Added typedData dependency"/>
     <environment ref="simple"/>
+    <dependency type="feature" value="typedData"/>
     <test>node-type-annotation(//*:doc)</test>
     <result>
       <all-of>


### PR DESCRIPTION
There is one more test for `fn:node-type-annotations` that requires typed data, but is missing the dependency to the optional `typedData` feature, which is added by this change.