### PR TITLE
Remove ‘XP40+’ dependency from tests that do not conform to XPath 4.0 grammar

### DIFF
--- a/fn/highest.xml
+++ b/fn/highest.xml
@@ -50,6 +50,8 @@
    <test-case name="highest-004">
       <description>test highest() with a default collation</description>
       <created by="Michael Kay" on="2014-04-13"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>
          declare default collation 'http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive';
          highest(doc('highest/highest-003.xml')/*/*, (), string#1)        

--- a/fn/load-xquery-module.xml
+++ b/fn/load-xquery-module.xml
@@ -1255,7 +1255,8 @@
   <test-case name="fn-load-xquery-module-401" covers-40="PR1333">
     <description>Loads a module using the 'content' option.</description>
     <created by="Michael Kay" on="2024-07-23"/>
-    <dependency type="spec" value="XP40+ XQ40+"/>
+    <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+    <dependency type="spec" value="XQ40+"/>
     
     <module uri="http://www.w3.org/fots/fn/load-xquery-module/valid/module" file="load-xquery-module/valid-module.xqm"/>
     <test>
@@ -1300,7 +1301,8 @@
   <test-case name="fn-load-xquery-module-402" covers-40="PR1333">
     <description>Static base URI using the 'content' option.</description>
     <created by="Michael Kay" on="2024-07-23"/>
-    <dependency type="spec" value="XP40+ XQ40+"/>
+    <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+    <dependency type="spec" value="XQ40+"/>
     
     <module uri="http://www.w3.org/fots/fn/load-xquery-module/valid/module" file="load-xquery-module/valid-module.xqm"/>
     <test>

--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -3004,7 +3004,8 @@
     <test-case name="serialize-json-202" covers="fn-serialize json-output" covers-40="PR1497">
         <description>json-lines serialization</description>
         <created by="Christian Gruen" on="2025-01-22"/>
-        <dependency type="spec" value="XP40+ XQ40+"/>
+        <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+        <dependency type="spec" value="XQ40+"/>
         <test><![CDATA[
 (1, true(), 's', {}, [], <a/>)
 => serialize({ 'method': 'json', 'json-lines': true() })

--- a/misc/Subtyping.xml
+++ b/misc/Subtyping.xml
@@ -4,7 +4,7 @@
    <description>
         Tests for subtyping relationships.
    </description>
-   <dependency type="spec" value="XP40+ XQ40+"/>
+   <dependency type="spec" value="XQ40+"/>
    
    <test-case name="subtyping-001">
       <description>Atomic types</description>

--- a/prod/ArrayTest.xml
+++ b/prod/ArrayTest.xml
@@ -756,7 +756,8 @@ return $m
    <test-case name="ArrayTest-097" covers-40="PR1501">
       <description>Array coercion</description>
       <created by="Christian Gruen" on="2025-01-22"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>
 let $f as array(element()) := [ element a {} ]
 return local-name($f?*)

--- a/prod/ArrowExpr.xml
+++ b/prod/ArrowExpr.xml
@@ -714,7 +714,8 @@
     <test-case name="ArrowExpr-425" covers-40="PR1763">
         <description>An ordered expression is allowed in parens</description>
         <created by="Michael Kay" on="2025-02-18"/>
-        <dependency type="spec" value="XP40+ XQ40+"/>
+        <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+        <dependency type="spec" value="XQ40+"/>
         <test>-22 => (ordered{abs#1})()</test>
         <result>
             <assert-eq>22</assert-eq>

--- a/prod/DynamicFunctionCall.xml
+++ b/prod/DynamicFunctionCall.xml
@@ -52,6 +52,8 @@
    <test-case name="DynamicFunctionCall-003">
       <description>Test that arguments are atomized - constructor function</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := xs:integer#1
@@ -79,6 +81,8 @@
    <test-case name="DynamicFunctionCall-005">
       <description>Test that arguments are atomized - user-defined function</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := fn($in as xs:anyAtomicType) as xs:boolean { $in instance of xs:decimal }
@@ -91,6 +95,8 @@
    <test-case name="DynamicFunctionCall-006">
       <description>Test that arguments are atomized - enumeration type</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := fn($in as enum("a", "b", "c")) as xs:string { upper-case($in) }
@@ -103,6 +109,8 @@
    <test-case name="DynamicFunctionCall-007">
       <description>Test atomization failure - enumeration type</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := fn($in as enum("a", "b", "c")) as xs:string { upper-case($in) }
@@ -115,6 +123,8 @@
    <test-case name="DynamicFunctionCall-008" covers-30="dynamic-function-call">
       <description>Test that arguments are atomized - dynamic call to a user-defined function</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          declare function local:f($in as xs:anyAtomicType) as xs:boolean { $in instance of xs:decimal };
@@ -675,6 +685,8 @@
    <test-case name="DynamicFunctionCall-R-005">
       <description>Test that arguments are atomized - user-defined function - record test</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := fn($in as record(x as xs:anyAtomicType)) as xs:boolean { $in?x instance of xs:decimal }
@@ -687,6 +699,8 @@
    <test-case name="DynamicFunctionCall-R-006">
       <description>Test that arguments are atomized - enumeration type - record test</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := fn($in as record(x as enum("a", "b", "c"))) as xs:string { upper-case($in?x) }
@@ -699,6 +713,8 @@
    <test-case name="DynamicFunctionCall-R-007">
       <description>Test atomization failure - enumeration type - record test</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          let $f := fn($in as record(x as enum("a", "b", "c"))) as xs:string { upper-case($in?x) }
@@ -711,6 +727,8 @@
    <test-case name="DynamicFunctionCall-R-008">
       <description>Test that arguments are atomized - dynamic call to a user-defined function - record test</description>
       <created by="Michael Kay" on="2024-02-09"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <dependency type="feature" value="schemaValidation"/>
       <test><![CDATA[
          declare function local:f($in as record('x' as xs:anyAtomicType)) as xs:boolean { 

--- a/prod/FunctionCall.xml
+++ b/prod/FunctionCall.xml
@@ -2244,7 +2244,8 @@
    <test-case name="function-call-reserved-function-names-007a">
       <description>Keyword is not reserved anymore with version 4.0.</description>
       <created by="Christian Gruen" on="2024-05-22"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>
 	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function local:item($arg) { fn:true() };

--- a/prod/MapTest.xml
+++ b/prod/MapTest.xml
@@ -786,7 +786,8 @@ return map:keys($f) instance of xs:byte
    <test-case name="MapTest-087" covers-40="PR1501">
       <description>Map coercion</description>
       <created by="Christian Gruen" on="2025-01-22"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40 dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>
 let $f as map(xs:integer, element()) := { 1: element a {} }
 return local-name($f?*)

--- a/prod/StringTemplate.xml
+++ b/prod/StringTemplate.xml
@@ -662,6 +662,8 @@ bottles`
    <test-case name="string-template-919">
       <description>Disallowed tokenization - special rule to avoid ambiguity</description>
       <created by="Michael Kay" on="2023-01-31"/>
+      <modified by="Gunther Rademacher" on="2025-02-27" change="Added XQ40 dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>``[1]</test>
       <result>
          <error code="XPST0003"/>


### PR DESCRIPTION
Many tests have dependencies in the form 

```
<dependency type="spec" value="XP40+ XQ40+"/>
```

However, some of them only parse correctly with XQuery 4.0, not with XPath 4.0.

This change removes the `XP40+` annotations for these cases.