### PR TITLE
Make tests for `parse-xml` option `strip-space` independent of boundary space

### DIFF
--- a/fn/parse-xml-fragment.xml
+++ b/fn/parse-xml-fragment.xml
@@ -323,34 +323,37 @@
     <test-case name="parse-xml-fragment-420" covers-40="PR1257">
         <description>parse-xml-fragment test - whitespace stripping on</description>
         <created by="Michael Kay, Saxonica" on="2024-06-11"/>        
+        <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space"/>
         <environment name="empty"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
-        <test><![CDATA[parse-xml-fragment('<a> <b/> </a> <c/>', {'strip-space': true()})]]></test>
+        <test><![CDATA[parse-xml-fragment('<a> <b/> </a> <c/>', {'strip-space': true()})//text() => count()]]></test>
         <result>
-            <assert-xml><![CDATA[<a><b/></a><c/>]]></assert-xml>
+            <assert-eq>0</assert-eq>
         </result>
     </test-case>
     
     <test-case name="parse-xml-fragment-421" covers-40="PR1257">
         <description>parse-xml-fragment test - whitespace stripping off</description>
         <created by="Michael Kay, Saxonica" on="2024-06-11"/>        
+        <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space"/>
         <environment name="empty"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
-        <test><![CDATA[parse-xml-fragment('<a> <b/> </a> <c/>', {'strip-space': false()})]]></test>
+        <test><![CDATA[parse-xml-fragment('<a> <b/> </a> <c/>', {'strip-space': false()})//text() => count()]]></test>
         <result>
-            <assert-xml><![CDATA[<a> <b/> </a> <c/>]]></assert-xml>
+            <assert-eq>3</assert-eq>
         </result>
     </test-case>
     
     <test-case name="parse-xml-fragment-422" covers-40="PR1257">
         <description>parse-xml-fragment test - whitespace stripping on with xml:space</description>
         <created by="Michael Kay, Saxonica" on="2024-06-11"/>        
+        <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space"/>
         <environment name="empty"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[parse-xml-fragment('<a><b> </b><b xml:space="preserve"> </b></a> <c/> ', 
-                                 {'strip-space': true()})]]></test>
+                                 {'strip-space': true()})//text() => count()]]></test>
         <result>
-            <assert-xml><![CDATA[<a><b/><b xml:space="preserve"> </b></a><c/>]]></assert-xml>
+            <assert-eq>1</assert-eq>
         </result>
     </test-case>
     

--- a/fn/parse-xml.xml
+++ b/fn/parse-xml.xml
@@ -288,34 +288,37 @@
     <test-case name="parse-xml-420" covers-40="PR1257">
         <description>parse-xml test - whitespace stripping on</description>
         <created by="Michael Kay, Saxonica" on="2024-06-11"/>        
+        <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space"/>
         <environment ref="empty"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
-        <test><![CDATA[parse-xml('<a> <b/> </a>', {'strip-space': true()})]]></test>
+        <test><![CDATA[parse-xml('<a> <b/> </a>', {'strip-space': true()})//text() => count()]]></test>
         <result>
-            <assert-xml><![CDATA[<a><b/></a>]]></assert-xml>
+            <assert-eq>0</assert-eq>
         </result>
     </test-case>
     
     <test-case name="parse-xml-421" covers-40="PR1257">
         <description>parse-xml test - whitespace stripping off</description>
         <created by="Michael Kay, Saxonica" on="2024-06-11"/>        
+        <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space"/>
         <environment ref="empty"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
-        <test><![CDATA[parse-xml('<a> <b/> </a>', {'strip-space': false()})]]></test>
+        <test><![CDATA[parse-xml('<a> <b/> </a>', {'strip-space': false()})//text() => count()]]></test>
         <result>
-            <assert-xml><![CDATA[<a> <b/> </a>]]></assert-xml>
+            <assert-eq>2</assert-eq>
         </result>
     </test-case>
     
     <test-case name="parse-xml-422" covers-40="PR1257">
         <description>parse-xml test - whitespace stripping on with xml:space</description>
         <created by="Michael Kay, Saxonica" on="2024-06-11"/>        
+        <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space"/>
         <environment ref="empty"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[parse-xml('<a><b> </b><b xml:space="preserve"> </b></a>', 
-                                 {'strip-space': true()})]]></test>
+                                 {'strip-space': true()})//text() => count()]]></test>
         <result>
-            <assert-xml><![CDATA[<a><b/><b xml:space="preserve"> </b></a>]]></assert-xml>
+            <assert-eq>1</assert-eq>
         </result>
     </test-case>
     

--- a/prod/ForClause.xml
+++ b/prod/ForClause.xml
@@ -1725,15 +1725,16 @@
    <test-case name="ForExprType009">
       <description> FLWOR with type expression matching a user defined type </description>
       <created by="Mike Rorke" on="2005-06-27"/>
+      <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space in result"/>
       <environment ref="orderData"/>
       <dependency type="spec" value="XQ10+"/>
       <test>
         declare namespace xqt="http://www.w3.org/XQueryTestOrderBy"; 
-        for $num as element(xqt:NegativeNumbers) in /xqt:DataValues/xqt:NegativeNumbers return $num</test>
+        for $num as element(xqt:NegativeNumbers) in /xqt:DataValues/xqt:NegativeNumbers return $num/xqt:orderData/data()</test>
       <result>
          <any-of>
-            <assert-xml><![CDATA[<NegativeNumbers xmlns="http://www.w3.org/XQueryTestOrderBy"><orderData>-100000000000000000</orderData><orderData>-10000000000000000</orderData><orderData>-1000000000000000</orderData><orderData>-100000000000000</orderData><orderData>-10000000000000</orderData><orderData>-1000000000000</orderData><orderData>-100000000000</orderData><orderData>-10000000000</orderData><orderData>-1000000000</orderData><orderData>-100000000</orderData><orderData>-10000000</orderData><orderData>-1000000</orderData><orderData>-100000</orderData><orderData>-10000</orderData><orderData>-1000</orderData><orderData>-100</orderData><orderData>-10</orderData><orderData>-1</orderData><orderData>0</orderData></NegativeNumbers>]]></assert-xml>
-            <assert-xml><![CDATA[<NegativeNumbers xmlns="http://www.w3.org/XQueryTestOrderBy"><orderData>-100000000000000000</orderData><orderData>-10000000000000000</orderData><orderData>-1000000000000000</orderData><orderData>-100000000000000</orderData><orderData>-10000000000000</orderData><orderData>-1000000000000</orderData><orderData>-100000000000</orderData><orderData>-10000000000</orderData><orderData>-1000000000</orderData><orderData>-100000000</orderData><orderData>-10000000</orderData><orderData>-1000000</orderData><orderData>-100000</orderData><orderData>-10000</orderData><orderData>-1000</orderData><orderData>-100</orderData><orderData>-10</orderData><orderData>-1</orderData><orderData>-0</orderData></NegativeNumbers>]]></assert-xml>
+            <assert-string-value>-100000000000000000 -10000000000000000 -1000000000000000 -100000000000000 -10000000000000 -1000000000000 -100000000000 -10000000000 -1000000000 -100000000 -10000000 -1000000 -100000 -10000 -1000 -100 -10 -1 0</assert-string-value>
+            <assert-string-value>-100000000000000000 -10000000000000000 -1000000000000000 -100000000000000 -10000000000000 -1000000000000 -100000000000 -10000000000 -1000000000 -100000000 -10000000 -1000000 -100000 -10000 -1000 -100 -10 -1 -0</assert-string-value>
          </any-of>
       </result>
    </test-case>

--- a/prod/WhileClause.xml
+++ b/prod/WhileClause.xml
@@ -106,6 +106,7 @@
       <description> For+While+Return - In the inner For+While+Return, uses outer variable in 'While' expr </description>
       <created by="Jinghao Liu" on="2003-02-10"/>
       <modified by="Michael Kay" on="2024-01-11" change="adapted 'where' test to create 'while' test"/>
+      <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space in result"/>
       <environment ref="fsx"/>
       <test><![CDATA[
          for $folder in /MyComputer/Drive4//Folder 
@@ -115,22 +116,7 @@
             return <File>{ $file/@name }</File> }</Folder>
       ]]></test>
       <result>
-         <assert-xml><![CDATA[
-            <Folder name="Folder00000000047"/>
-            <Folder name="Folder00000000048">
-               <File name="File00000000077"/>
-               <File name="File00000000078"/>
-               <File name="File00000000079"/>
-               <File name="File00000000080"/>
-               <File name="File00000000081"/>
-            </Folder>
-            <Folder name="Folder00000000049"/>
-            <Folder name="Folder00000000050"/>
-            <Folder name="Folder00000000051"/>
-            <Folder name="Folder00000000052"/>
-            <Folder name="Folder00000000053"/>
-            <Folder name="Folder00000000054"/>
-         ]]></assert-xml>
+         <assert-xml><![CDATA[<Folder name="Folder00000000047"/><Folder name="Folder00000000048"><File name="File00000000077"/><File name="File00000000078"/><File name="File00000000079"/><File name="File00000000080"/><File name="File00000000081"/></Folder><Folder name="Folder00000000049"/><Folder name="Folder00000000050"/><Folder name="Folder00000000051"/><Folder name="Folder00000000052"/><Folder name="Folder00000000053"/><Folder name="Folder00000000054"/>]]></assert-xml>
       </result>
    </test-case>
 
@@ -138,16 +124,11 @@
       <description> For+While+Return - 2 iterations use 'While' to build relationship </description>
       <created by="Jinghao Liu" on="2003-02-10"/>
       <modified by="Michael Kay" on="2024-01-11" change="adapted 'where' test to create 'while' test"/>
+      <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space in result"/>
       <environment ref="fsx"/>
       <test><![CDATA[<fragment-result>{ for $folder in /MyComputer/Drive3/Folder ,$file in /MyComputer/Drive3/Folder/File while $folder/@id = $file/@idref return <Folder> { $folder/@name, $folder/@id } <file>{ $file/@idref, $file/FileName/text() }</file> </Folder> }</fragment-result>]]></test>
       <result>
-         <assert-xml><![CDATA[
-            <fragment-result>
-               <Folder name="Folder00000000017" id="67">
-                  <file idref="67">File00000000047</file>
-               </Folder>
-            </fragment-result>
-         ]]></assert-xml>
+         <assert-xml><![CDATA[<fragment-result><Folder name="Folder00000000017" id="67"><file idref="67">File00000000047</file></Folder></fragment-result>]]></assert-xml>
       </result>
    </test-case>
 
@@ -1047,23 +1028,13 @@
       <description> A left outer join that requires tricky predicate hoisting to spot. </description>
       <created by="Oliver Hallam" on="2008-07-23"/>      
       <modified by="Michael Kay" on="2024-01-11" change="adapted 'where' test to create 'while' test"/>
+      <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space in result"/>
       <test><![CDATA[
          <e> { for $x in 1 to 10 return <a>{
                   for $y in 1 to 10 while $x > 7 and $y = $x return $y
                }</a> } </e>]]></test>
       <result>
-         <assert-xml><![CDATA[<e>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-   <a/>
-</e>]]></assert-xml>
+         <assert-xml><![CDATA[<e><a/><a/><a/><a/><a/><a/><a/><a/><a/><a/></e>]]></assert-xml>
       </result>
    </test-case>
    
@@ -1085,6 +1056,7 @@
       <description/>
       <created by="Nick Jones" on="2010-03-24"/>      
       <modified by="Michael Kay" on="2024-01-11" change="adapted 'where' test to create 'while' test"/>
+      <modified by="Gunther Rademacher" on="2025-03-04" change="Make test independent of boundary space in result"/>
       <test><![CDATA[<tbody> { 
          let $rows := <tables> <table> <row> <entry>Acetazolamide</entry> <entry>Acetazolamide</entry> </row> <row> <entry>Acetazolamide sodium</entry> <entry>Acetazolamide sodium</entry> </row> </table> <table> <row> <entry>Acetylcholine chloride</entry> <entry>Acetylcholine chloride</entry> </row> </table> <table> <row> <entry>Acetylcysteine</entry> <entry>Acetylcysteine</entry> </row> <row> <entry>Acetylcysteine sodium</entry> <entry>Acetylcysteine sodium</entry> </row> </table> </tables>/table/row 
          return for $g in distinct-values($rows/entry[2][string(.)])  
@@ -1095,15 +1067,7 @@
                        return <entry> { $matches/( <link> { node() } </link>, text { if (position() lt last()) then '; ' else () } ) } </entry> 
          } </tbody>]]></test>
       <result>
-         <assert-xml><![CDATA[<tbody>
-   <entry>
-      <link>Acetazolamide</link>
-   </entry>
-   <entry/>
-   <entry/>
-   <entry/>
-   <entry/>
-</tbody>]]></assert-xml>
+         <assert-xml><![CDATA[<tbody><entry><link>Acetazolamide</link></entry><entry/><entry/><entry/><entry/></tbody>]]></assert-xml>
       </result>
    </test-case>
    


### PR DESCRIPTION
Apparently the comparison of test results must be performed under conditions where boundary space is stripped. If it were preserved, 8 tests would fail, e.g.

  - [`ForExprType009`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/prod/ForClause.xml#L1725-L1739)
  - [`WhileExpr0006`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/prod/WhileClause.xml#L105-L135)
  - [`WhileExpr007`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/prod/WhileClause.xml#L137-L152)

However with boundary space stripped, the currently expected test results for option `strip-space` of `parse-xml` and `parse-xml-fragment` would compare OK regardless of whether the option is implemented or not.

This change thus moves text node detection into the query and changes result comparison accordingly.