### PR TITLE
Adapt test case `d1e48709` to changed behaviour of `fn:apply`

### DIFF
--- a/app/Walmsley.xml
+++ b/app/Walmsley.xml
@@ -1244,12 +1244,26 @@ return apply($f,["a"])]]></test>
    <test-case name="d1e48709" covers="fn-apply">
       <description>apply row 4</description>
       <created by="Priscilla Walmsley" on="2015-06-10"/>
+      <modified by="Gunther Rademacher" on="2025-03-05" change="Added dependency."/>
+      <dependency type="spec" value="XP31 XQ31"/>
       <dependency type="feature" value="higherOrderFunctions"/>
       <environment ref="all"/>
       <test><![CDATA[
  apply(upper-case#1,['a','b'])]]></test>
       <result>
          <error code="FOAP0001"/>
+      </result>
+   </test-case>
+   <test-case name="d1e48709a" covers="fn-apply">
+      <description>Same as d1e48709, but XQ40+ ignores excess arguments.</description>
+      <created by="Gunther Rademacher" on="2025-03-05"/>
+       <dependency type="spec" value="XP40+ XQ40+"/>
+      <dependency type="feature" value="higherOrderFunctions"/>
+      <environment ref="all"/>
+      <test><![CDATA[
+ apply(upper-case#1,['a','b'])]]></test>
+      <result>
+         <assert-eq>"A"</assert-eq>
       </result>
    </test-case>
    <test-case name="d1e51544" covers="map-contains">


### PR DESCRIPTION
The behaviour of `fn:apply` with respect to excessive arguments has been changed from raising `err:FOAP0001` to ignoring them in qt4cg/qtspecs#1280.

This change adapts test case  `d1e48709`.

Also note that tests for `fn:chain` might need to be changed, as suggested in qt4cg/qtspecs#1859. There is one test that might be affected, `fo-test-fn-chain-019`, which however is a generated test.
