### PR TITLE
Add missing empty fn:match to the expected result of `analyzeString-903a`

### DIFF
--- a/fn/analyze-string.xml
+++ b/fn/analyze-string.xml
@@ -459,12 +459,14 @@ it put its sooty foot.</fn:non-match></fn:analyze-string-result>]]></assert-xml>
    <test-case name="analyzeString-903a" covers-40="PR1856">
       <description> analyze-string, no error in 4.0, pattern matches a zero-length string </description>
       <created by="Michael Kay" on="2025-03-11"/>
+      <modified by="Gunther Rademacher" on="2025-04-02" change="add missing empty fn:match at the end"/>
       <test>analyze-string("abc", "a|b|c?")</test>
       <result>
             <assert-xml ignore-prefixes="true"><![CDATA[<analyze-string-result xmlns="http://www.w3.org/2005/xpath-functions">
    <match>a</match>
    <match>b</match>
    <match>c</match>
+   <match/>
 </analyze-string-result>]]></assert-xml>
       </result>
    </test-case>


### PR DESCRIPTION
There are four matches that can be reported by `analyze-string("abc", "a|b|c?")`, and the spec does not say that the final empty match should be suppressed, so this change is adding it to the expected result.