### PR TITLE
Add missing replacement string to the expected result of `fn-replace-114`

### DIFF
--- a/fn/replace.xml
+++ b/fn/replace.xml
@@ -1087,10 +1087,11 @@ abracadabra", "\n","with")</test>
       <description>Error: empty replacement pattern</description>
       <created by="Christian Gruen" on="2022-08-17"/>
       <modified by="Michael Kay" on="2025-03-09" change="now allowed"/>
+      <modified by="Gunther Rademacher" on="2025-04-04" change="add replacement for second match"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test><![CDATA[fn:replace("W", ".*", (), (), function($k, $g) {"~"})]]></test>
       <result>
-         <assert-string-value>~</assert-string-value>
+         <assert-string-value>~~</assert-string-value>
       </result>
    </test-case>
    <test-case name="fn-replace-115">


### PR DESCRIPTION
Test case `fn-replace-114` expects this function call to return a single `~` character:

```xquery
fn:replace("W", ".*", (), (), function($k, $g) {"~"})
```

However, the disjoint matching segments are `1,1` and `2,0`, and there is no rule in the spec saying that the final empty match should be omitted. So there should be two instances of the replacement in the result.

This change is thus correcting the expected result accordingly.