### PR TITLE
Test cases relating to new options of `fn:doc`, `fn:doc-available`, and `fn:parse-xml`

### DIFF
--- a/fn/doc-available.xml
+++ b/fn/doc-available.xml
@@ -4,12 +4,32 @@
    <link type="spec" document="http://www.w3.org/TR/xpath-functions-30/"
          idref="func-doc-available"/>
 
+   <environment name="works-mod-uri">
+      <source role="." file="../docs/works-mod.xml" uri="http://www.w3.org/fots/docs/works-mod.xml">
+         <description>Data for various NIST tests (abbreviated, unabbreviated syntax)</description>
+         <created by="Carmelo Montanez" on="2005-03-04"/>
+      </source>
+      <param name="uri" as="xs:string" select="'http://www.w3.org/fots/docs/works-mod.xml'" declared="false"/>
+   </environment>
+
    <test-case name="fn-doc-available-1">
       <description> Evaluation of ana fn:doc-available function with wrong arity. </description>
       <created by="Carmelo Montanez" on="2006-07-11"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="add dependency"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:doc-available("http://example.com","string 2")</test>
       <result>
          <error code="XPST0017"/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-doc-available-1a">
+      <description>Same as fn-doc-available-1, but second argument permitted in 4.0.</description>
+      <created by="Gunther Rademacher" on="2025-04-23"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:doc-available("http://example.com","string 2")</test>
+      <result>
+         <error code="XPTY0004"/>
       </result>
    </test-case>
 
@@ -203,8 +223,9 @@
    <test-case name="fn-doc-available-40-017" covers-40="PR1910">
       <description>Options on fn:doc-available - dtd validation, document valid, internal DTD with external entities, allow-external-entities=true</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="removed excess left parenthesis"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test>(fn:doc-available("../docs/bib-with-internal-dtd-and-external-entities.xml", {'dtd-validation':true(), 'allow-external-entities': true()})</test>
+      <test>fn:doc-available("../docs/bib-with-internal-dtd-and-external-entities.xml", {'dtd-validation':true(), 'allow-external-entities': true()})</test>
       <result>
          <assert-true/>
       </result>
@@ -243,10 +264,11 @@
    <test-case name="fn-doc-available-40-021" covers-40="PR1910">
       <description>Options on fn:doc-available - dtd validation, document valid, internal DTD with internal entities, entity-expansion-limit=10000</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="corrected expected response (test does not exceed entity expansion limit)"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>fn:doc-available("../docs/bib-with-internal-dtd-and-internal-entities.xml", {'dtd-validation':true(), 'entity-expansion-limit':10000})</test>
       <result>
-         <assert-false/>
+         <assert-true/>
       </result>
    </test-case>
    

--- a/fn/doc.xml
+++ b/fn/doc.xml
@@ -51,9 +51,21 @@
    <test-case name="fn-doc-2">
       <description> Evaluation of fn:doc function with wrong arity. </description>
       <created by="Carmelo Montanez" on="2005-11-30"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="add dependency"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:doc("argument1","argument2")</test>
       <result>
          <error code="XPST0017"/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-doc-2a" covers="fn-doc" covers-40="PR1910">
+      <description>Same as fn-doc-2, but second argument permitted in 4.0.</description>
+      <created by="Gunther Rademacher" on="2025-04-23"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:doc("argument1","argument2")</test>
+      <result>
+         <error code="XPTY0004"/>
       </result>
    </test-case>
 
@@ -658,20 +670,28 @@
    <test-case name="fn-doc-40-011" covers-40="PR1910">
       <description>Options on fn:doc - dtd validation requested, no DTD available</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="XML parser reports a DTD validation error, so added response code FODC0007"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib.xml", {'dtd-validation':true()})/*)</test>
       <result>
-         <error code="FODC0002"/>
+         <any-of>
+            <error code="FODC0002"/>
+            <error code="FODC0007"/>
+         </any-of>
       </result>
    </test-case>
    
    <test-case name="fn-doc-40-012" covers-40="PR1910">
       <description>Options on fn:doc - dtd validation requested, document is invalid</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="XML parser reports a DTD validation error, so added response code FODC0007"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib-invalid.xml", {'dtd-validation':true()})/*)</test>
       <result>
-         <error code="FODC0002"/>
+         <any-of>
+            <error code="FODC0002"/>
+            <error code="FODC0007"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -698,10 +718,14 @@
    <test-case name="fn-doc-40-015" covers-40="PR1910">
       <description>Options on fn:doc - dtd validation, document valid, external DTD, allow-external-entities=false</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="Entity resolver reports access to blocked external URI, so added response code FODC0002"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib-with-external-dtd.xml", {'dtd-validation':true(), 'allow-external-entities': false()})/*)</test>
       <result>
-         <error code="FODC0006"/>
+         <any-of>
+            <error code="FODC0002"/>
+            <error code="FODC0006"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -728,10 +752,14 @@
    <test-case name="fn-doc-40-018" covers-40="PR1910">
       <description>Options on fn:doc - dtd validation, document valid, internal DTD with external entities, allow-external-entities=false</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="Entity resolver reports access to blocked external URI, so added response code FODC0002"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib-with-internal-dtd-and-external-entities.xml", {'dtd-validation':true(), 'allow-external-entities': false()})//title[contains(., 'XSLT')])</test>
       <result>
-         <error code="FODC0006"/>
+         <any-of>
+            <error code="FODC0002"/>
+            <error code="FODC0006"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -748,10 +776,14 @@
    <test-case name="fn-doc-40-020" covers-40="PR1910">
       <description>Options on fn:doc - dtd validation, document valid, internal DTD with external entities, entity-expansion-limit=0</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="reported as a parsing failure, so added response code FODC0002"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib-with-internal-dtd-and-external-entities.xml", {'dtd-validation':true(), 'entity-expansion-limit':1})//title[contains(., 'TCP/IP')])</test>
       <result>
-         <error code="FODC0006"/>
+         <any-of>
+            <error code="FODC0002"/>
+            <error code="FODC0006"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -768,10 +800,14 @@
    <test-case name="fn-doc-40-022" covers-40="PR1910">
       <description>Options on fn:doc - dtd validation, document valid, internal DTD with internal entities, entity-expansion-limit=20</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="reported as a parsing failure, so added response code FODC0002"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib-with-internal-dtd-and-internal-entities.xml", {'dtd-validation':true(), 'entity-expansion-limit':20})//title[contains(., 'TCP/IP')])</test>
       <result>
-         <error code="FODC0006"/>
+         <any-of>
+            <error code="FODC0002"/>
+            <error code="FODC0006"/>
+         </any-of>
       </result>
    </test-case>
    
@@ -879,7 +915,9 @@
    <test-case name="fn-doc-40-045" covers-40="PR1910">
       <description>Options on fn:doc - stable with schema validation</description>
       <created by="Michael Kay" on="2025-04-08"/>
+      <modified by="Gunther Rademacher" on="2025-04-23" change="added missing dependency to schemaImport feature"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
+      <dependency type="feature" value="schemaImport"/>
       <environment ref="bib-with-schema"/>
       <test>fn:doc("../docs/bib.xml", {'stable':true(), 'xsd-validation':'strict'})
           is fn:doc("../docs/bib.xml", {'stable':true(), 'xsd-validation':'skip'}) </test>

--- a/fn/parse-xml.xml
+++ b/fn/parse-xml.xml
@@ -518,9 +518,10 @@
     <test-case name="parse-xml-451" covers-40="PR1879">
         <description>parse-xml test - with external DTD, not OK because disallowed</description>
         <created by="Michael Kay" on="2025-03-26"/>        
+        <modified by="Gunther Rademacher" on="2025-04-23" change="add 'dtd-validation': true()"/>
         <environment name="empty"/>
         <test><![CDATA[parse-xml("<!DOCTYPE a SYSTEM 'parse-xml/a.dtd'><a>foo</a>",
-            { 'allow-external-entities': false() } )]]></test>
+            { 'dtd-validation': true(), 'allow-external-entities': false() } )]]></test>
         <result>
             <error code="FODC0006"/>
         </result>


### PR DESCRIPTION
These fixes came up while working on the new options:

**`fn/doc-available.xml`**

- added missing environment `works-mod-uri`
- `fn-doc-available-1`: `fn:doc-available` now allows two parameters. so added a dependency on versions before 4.0
- `fn-doc-available-1a`: spawned from `fn-doc-available-1` to reflect 4.0 behaviour
- `fn-doc-available-40-017`: removed excess left parenthesis
- `fn-doc-available-40-021`: corrected expected response (test does not exceed entity expansion limit)

**`fn/doc.xml`**

- `fn-doc-2`: `fn:doc-available` now allows two parameters. so added a dependency on versions before 4.0
- `fn-doc-2a`: spawned from `fn-doc-2` to reflect 4.0 behaviour
- `fn-doc-40-011`: XML parser reports a DTD validation error, so added response code `FODC0007`
- `fn-doc-40-012`: XML parser reports a DTD validation error, so added response code `FODC0007`
- `fn-doc-40-015`: Entity resolver reports access to blocked external URI, so added response code `FODC0002`
- `fn-doc-40-018`: Entity resolver reports access to blocked external URI, so added response code `FODC0002`
- `fn-doc-40-020`: exceeding the entity expansion limit is reported as a parsing failure, so added response code `FODC0002`
- `fn-doc-40-022`: exceeding the entity expansion limit is reported as a parsing failure, so added response code `FODC0002`
- `fn-doc-40-045`: added missing dependency to `schemaImport` feature  

**`fn/parse-xml.xml`**

- `parse-xml-451`: added missing `add 'dtd-validation': true()
