### PR TITLE
Corrections of new tests

### DIFF
--- a/fn/element-to-map-plan.xml
+++ b/fn/element-to-map-plan.xml
@@ -239,6 +239,8 @@
    <test-case name="element-to-map-plan-700">
       <description> Equivalence of the "formal equivalent" implementation </description>
       <created by="Michael Kay" on="2025-03-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
          let $equivalent := function($input as node()*) as map(*) {
            (: the formal equivalent from the spec :)

--- a/fn/xsd-validator.xml
+++ b/fn/xsd-validator.xml
@@ -441,7 +441,9 @@
    <test-case name="xsd-validator-024">
       <description> Test for the correct typed value when a list of union types is used. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="ListUnionTypes"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         declare namespace lu = 'http://www.w3.org/XQueryTest/ListUnionTypes' ;
         import schema "http://www.w3.org/XQueryTest/ListUnionTypes";
@@ -457,7 +459,9 @@
    <test-case name="xsd-validator-025">
       <description> Test returned error details. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="simplexsd"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace simple="http://www.w3.org/XQueryTest/simple";
         xsd-validator() (<simple:duration>sorry, no duration here</simple:duration>) ? error-details
@@ -474,6 +478,8 @@
    <test-case name="xsd-validator-026">
       <description> Test For error condition XQDY0061 using a document node. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         xsd-validator() ( document { <a/>, <b/> } ) ? is-valid
       ]]></test>
@@ -531,7 +537,9 @@
    <test-case name="xsd-validator-029">
       <description>Name : xsd-validator-0029  Test For error condition XQDY0061 using a document node. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="orderData"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ns="http://www.w3.org/XQueryTestOrderBy";
         xsd-validator() ( document { <ns:Strings/>, <ns:Strings/> } )
@@ -546,7 +554,9 @@
          (with processing instructions and comments) does not throw a type error in 
          static typing implementations when used as an expression of type document(). </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="orderData"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema default element namespace "http://www.w3.org/XQueryTestOrderBy";
         let $document as document-node(element(Strings)) := document { 
@@ -564,7 +574,9 @@
       <description>Name : xsd-validator-0031  Test that validating a union of element nodes
          does not raise a type error. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="orderData"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema default element namespace "http://www.w3.org/XQueryTestOrderBy";
         declare function local:numbers($positive) { 
@@ -585,7 +597,9 @@
       <description>Name : xsd-validator-0032  Test that validating a union of document nodes
          does not raise a type error. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="orderData"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema default element namespace "http://www.w3.org/XQueryTestOrderBy";
         declare function local:numbers($positive) { 
@@ -606,7 +620,9 @@
       <description>Name : xsd-validator-0033  Test that validating a union of element and 
          document nodes does not raise a type error. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="orderData"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema default element namespace "http://www.w3.org/XQueryTestOrderBy";
         declare function local:numbers($positive) { 
@@ -638,6 +654,8 @@
    <test-case name="xsd-validator-035">
       <description> Lax validation using xsi:type </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         xsd-validator({'validation-mode':'lax'}) ( <a xsi:type='xs:integer' xmlns:xs="http://www.w3.org/2001/XMLSchema">42</a> ) ? is-valid
       ]]></test>
@@ -649,7 +667,9 @@
    <test-case name="xsd-validator-036">
       <description> Validation using xs:NOTATION </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="user-defined-types"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace udt = "http://www.w3.org/XQueryTest/userDefinedTypes";
         string( xsd-validator({'validation-mode':'lax'}) ( <a xsi:type='udt:NOTATIONBased'
@@ -773,7 +793,9 @@
    <test-case name="xsd-validator-051">
       <description> Test validation of elements with unique/id/idref schema constraints </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="constraints"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace constraints = "http://www.w3.org/constraints";
         declare variable $test := element test { <constraints:a> <b id="x"/> <b id="y"/> <b id="y"/> </constraints:a> };
@@ -787,7 +809,9 @@
    <test-case name="xsd-validator-052">
       <description> Test validation of elements with unique/id/idref schema constraints </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="constraints"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace constraints = "http://www.w3.org/constraints";
         declare variable $test := element test { <constraints:a2> <b2 id="x"/> <b2 id="y"/> <b2/> </constraints:a2> };
@@ -801,7 +825,9 @@
    <test-case name="xsd-validator-053">
       <description> Test validation of elements with unique/id/idref schema constraints </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="constraints"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace constraints = "http://www.w3.org/constraints";
         declare variable $test := element test { <constraints:a2> <b2 id="x"/> <b2 id="y"/> <b2 id="z"/> <b2ref> <c idref="x"/> <c idref="y"/> <c idref="q"/> </b2ref> </constraints:a2> };
@@ -815,7 +841,9 @@
    <test-case name="xsd-validator-054">
       <description> Test validation of elements with unique/id/idref schema constraints </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="constraints"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace constraints = "http://www.w3.org/constraints";
         declare variable $test := element test { <constraints:a> <b id="x"/> <b id="y"/> </constraints:a> };
@@ -829,7 +857,9 @@
    <test-case name="xsd-validator-055">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:complexExtendsSimple>1</ss:complexExtendsSimple> ) ? typed-node 
@@ -844,7 +874,9 @@
    <test-case name="xsd-validator-056">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:emptyMixed>1</ss:emptyMixed> ) ? typed-node 
@@ -859,7 +891,9 @@
    <test-case name="xsd-validator-057">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:unionBase>1</ss:unionBase> ) ? typed-node 
@@ -874,7 +908,9 @@
    <test-case name="xsd-validator-058">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:unionBase>2</ss:unionBase> ) ? typed-node  
@@ -888,7 +924,9 @@
    <test-case name="xsd-validator-059">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:complexExtendsUnion>1</ss:complexExtendsUnion> ) ? typed-node  
@@ -902,7 +940,9 @@
    <test-case name="xsd-validator-060">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:complexExtendsUnion>2</ss:complexExtendsUnion> ) ? typed-node  
@@ -916,7 +956,9 @@
    <test-case name="xsd-validator-061">
       <description/>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="complexSimple"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
         import schema namespace ss="http://www.w3.org/query-test/complexSimple";
         let $v := xsd-validator() ( <ss:listBase>1</ss:listBase> ) ? typed-node  
@@ -1057,10 +1099,11 @@
    <test-case name="xsd-validator-074">
       <description>Undeclared namespace prefix in type name</description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="add missing semicolon"/>
       <environment ref="hats"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
-        import schema namespace hat = "http://www.w3.org/XQueryTest/hats"
+        import schema namespace hat = "http://www.w3.org/XQueryTest/hats";
         xsd-validator({'type': xs:QName('boot:hatsize')}) ( <hat>8</hat> )
       ]]></test>
       <result>
@@ -1244,6 +1287,8 @@
    <test-case name="xsd-validator-088">
       <description> Test validation on a document with no element nodes. </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>xsd-validator() ( document { "text" } )</test>
       <result>
          <error code="XPTY0004"/>
@@ -1293,7 +1338,9 @@
    <test-case name="xsd-validator-092">
       <description> Test validation of a global schema attribute (not allowed) </description>
       <created by="Michael Kay" on="2025-04-30"/>
+      <modified by="Gunther Rademacher" on="2025-05-10" change="changed dependency to XQuery only"/>
       <environment ref="validate"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>
         import schema namespace tc="http://www.w3.org/XQueryTest/testcases";
         xsd-validator() ( attribute { xs:QName("tc:a") } { "value" } )</test>


### PR DESCRIPTION
Test `xsd-validator-074` had a syntax error, a semicolon was missing.

A number of new tests had dependency `XP40+ XQ40+`, though they are not valid for XPath.

This was detected by the test processing for the [RExified](https://github.com/GuntherRademacher/rex-parser-generator/tree/main/docs/sample-grammars/XQuery-40) grammars.

As noted [here](https://github.com/GuntherRademacher/rex-parser-generator/blob/51b5302a5d1471592b3d24d60157131b2c5beadf/docs/sample-grammars/XQuery-40/process-tests.xq#L14-L30), there are also a few more problems with tests in [app/fo-spec-examples.xml](https://github.com/qt4cg/qt4tests/blob/master/app/fo-spec-examples.xml) , but those tests are generated ones.