### PR TITLE
Fix problems detected by parser tests

### DIFF
--- a/array/sort-by.xml
+++ b/array/sort-by.xml
@@ -312,6 +312,8 @@
     <test-case name="array-sort-by-022">
         <description>Variable length sort keys</description>
         <created by="Michael Kay" on="2016-08-18"/>
+        <modified by="Gunther Rademacher" on="2025-05-20" change="add dependency"/>
+        <dependency type="spec" value="XQ40+"/>
         <test><![CDATA[let
 	  $employees := [
 	    <emp id='1'><name><last>Cawcutt</last></name></emp>,

--- a/fn/sort-by.xml
+++ b/fn/sort-by.xml
@@ -475,6 +475,8 @@
          change="Add CDATA to test element (otherwise element constructors are treated as xml)"/>
       <modified by="Debbie Lockett" on="2015-02-27" change="Change dependency"/>
       <modified by="Michael Kay" on="2016-07-26" change="add collation argument, bug 29722"/>
+      <modified by="Gunther Rademacher" on="2025-05-20" change="add dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[let
 	  $employees := (
 	    <emp><name><first>Reginald</first><last>Cawcutt</last></name></emp>,
@@ -502,6 +504,8 @@
    <test-case name="fn-sort-by-spec-5">
       <description>Variable length sort-by keys</description>
       <created by="Michael Kay" on="2016-08-18"/>
+      <modified by="Gunther Rademacher" on="2025-05-20" change="add dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[let
 	  $employees := (
 	    <emp id='1'><name><last>Cawcutt</last></name></emp>,

--- a/prod/Literal.xml
+++ b/prod/Literal.xml
@@ -2343,7 +2343,6 @@ line2</assert-string-value>
       </test>
       <result>
          <assert-eq>"fn"</assert-eq>
-         <error code="XPST0003"/>
       </result>
    </test-case>
    


### PR DESCRIPTION
A few problems were found by [REx test processing](https://github.com/GuntherRademacher/rex-parser-generator/tree/main/docs/sample-grammars/XQuery-40):

- `fn-sort-by-spec-4` missing `XQ40+` dependency
- `fn-sort-by-spec-5` missing `XQ40+` dependency
- `array-sort-by-022` missing `XQ40+` dependency
- `Literals-40-925a` extraneous expected result since recent merge