### PR TITLE
Adapt tests to new `MarkedNCName` syntax

### DIFF
--- a/fn/type-of.xml
+++ b/fn/type-of.xml
@@ -90,8 +90,9 @@
   <test-case name="type-of-008">
     <description>Namespace node</description>
     <created by="Michael Kay" on="2024-10-22"/>
+    <modified by="Gunther Rademacher" on="2025-06-10" change="replace string by NCName literal, adapting to new syntax"/>
     <dependency type="spec" value="XQ40+"/>
-    <test><![CDATA[type-of(namespace "p" {"http://p.com/"})]]></test>
+    <test><![CDATA[type-of(namespace #p {"http://p.com/"})]]></test>
     <result>
       <assert-eq>"namespace-node()"</assert-eq>
     </result>

--- a/prod/CompNamespaceConstructor.xml
+++ b/prod/CompNamespaceConstructor.xml
@@ -700,23 +700,14 @@
   <test-case name="nscons-045" covers-40="PR1513">
       <description> Allow name to be a string literal </description>
       <created by="Michael Kay" on="2024-06-11"/>
+      <modified by="Gunther Rademacher" on="2025-06-10" change="replace string by NCName literal, adapting to new syntax"/>
       <dependency type="spec" value="XQ40+"/>
-      <test><![CDATA[<foo>{namespace "div" {'foo.ns'}}</foo>]]></test>
+      <test><![CDATA[<foo>{namespace #div {'foo.ns'}}</foo>]]></test>
       <result>
          <assert-xml><![CDATA[<foo xmlns:div="foo.ns"/>]]></assert-xml>
       </result>
    </test-case>
-   
-   <test-case name="nscons-046" covers-40="PR1513">
-      <description> Allow name to be a string literal </description>
-      <created by="Michael Kay" on="2024-06-11"/>
-      <dependency type="spec" value="XQ40+"/>
-      <test><![CDATA[<foo>{namespace " div " {'foo.ns'}}</foo>]]></test>
-      <result>
-         <assert-xml><![CDATA[<foo xmlns:div="foo.ns"/>]]></assert-xml>
-      </result>
-   </test-case>
-   
+
    <test-case name="nscons-047" covers-40="PR1513">
       <description> Disallow reserved names </description>
       <created by="Michael Kay" on="2024-06-11"/>

--- a/prod/CompPIConstructor.xml
+++ b/prod/CompPIConstructor.xml
@@ -547,23 +547,14 @@
    <test-case name="K2-ComputeConPI-14" covers-40="PR1513">
       <description> Allow name to be a string literal </description>
       <created by="Michael Kay" on="2024-06-11"/>
+      <modified by="Gunther Rademacher" on="2025-06-10" change="replace string by NCName literal, adapting to new syntax"/>
       <dependency type="spec" value="XQ40+"/>
-      <test><![CDATA[<foo>{processing-instruction "div" {}}</foo>]]></test>
+      <test><![CDATA[<foo>{processing-instruction #div {}}</foo>]]></test>
       <result>
          <assert-xml><![CDATA[<foo><?div?></foo>]]></assert-xml>
       </result>
    </test-case>
-   
-   <test-case name="K2-ComputeConPI-15" covers-40="PR1513">
-      <description> Allow name to be a string literal </description>
-      <created by="Michael Kay" on="2024-06-11"/>
-      <dependency type="spec" value="XQ40+"/>
-      <test><![CDATA[<foo>{processing-instruction " div " {}}</foo>]]></test>
-      <result>
-         <assert-xml><![CDATA[<foo><?div?></foo>]]></assert-xml>
-      </result>
-   </test-case>
-   
+
    <test-case name="K2-ComputeConPI-16" covers-40="PR1513">
       <description> Disallow reserved names </description>
       <created by="Michael Kay" on="2024-06-11"/>


### PR DESCRIPTION
Today's merge of qt4cg/qtspecs#2028 has removed the possibility to use a `StringLiteral` as a computed node NCName, in favor of the new `MarkedNCName`.

This change adapts the tests accordingly. 2 Tests have been removed, because changing them would make them duplicates to their preceding tests.