### PR TITLE
Adapt tests to changed whitespace allowance in `QNameLiteral` and `MarkedNCName`

### DIFF
--- a/prod/CompAttrConstructor.xml
+++ b/prod/CompAttrConstructor.xml
@@ -1051,10 +1051,11 @@
       <description> Allow name to be a QName literal </description>
       <created by="Michael Kay" on="2024-06-11"/>
       <modified by="Gunther Rademacher" on="2025-05-14" change="replace string by QName literal, adapting to new syntax"/>
+      <modified by="Gunther Rademacher" on="2025-06-24" change="whitespace now allowed, so replace XPST0003 by by result"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[<foo>{attribute # div  {}}</foo>]]></test>
       <result>
-         <error code="XPST0003"/>
+         <assert-xml><![CDATA[<foo div=""/>]]></assert-xml>
       </result>
    </test-case>
    

--- a/prod/CompElemConstructor.xml
+++ b/prod/CompElemConstructor.xml
@@ -794,10 +794,11 @@
       <description> QName literal cannot contain whitespace </description>
       <created by="Michael Kay" on="2024-06-11"/>
       <modified by="Gunther Rademacher" on="2025-05-14" change="replace string by QName literal, adapting to new syntax"/>
+      <modified by="Gunther Rademacher" on="2025-06-24" change="whitespace now allowed, so replace XPST0003 by by result"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[element # Q{}div {}]]></test>
       <result>
-         <error code="XPST0003"/>
+         <assert-xml><![CDATA[<div/>]]></assert-xml>
       </result>
    </test-case>
    

--- a/prod/CompNamespaceConstructor.xml
+++ b/prod/CompNamespaceConstructor.xml
@@ -712,10 +712,11 @@
       <description> No whitespace allowed after # </description>
       <created by="Michael Kay" on="2024-06-11"/>
       <modified by="Michael Kay" on="2025-06-04" change="syntax modified by PR2028"/>
+      <modified by="Gunther Rademacher" on="2025-06-24" change="whitespace now allowed, so replace XPST0003 by by result"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[<foo>{namespace # div {'foo.ns'}}</foo>]]></test>
       <result>
-         <error code="XPST0003"/>
+         <assert-xml><![CDATA[<foo xmlns:div="foo.ns"/>]]></assert-xml>
       </result>
    </test-case>
    

--- a/prod/CompPIConstructor.xml
+++ b/prod/CompPIConstructor.xml
@@ -559,10 +559,11 @@
       <description> Whitespace not allowed after # </description>
       <created by="Michael Kay" on="2024-06-11"/>
       <modified by="Michael Kay" on="2025-06-04" change="syntax modified by PR2028"/>
+      <modified by="Gunther Rademacher" on="2025-06-24" change="whitespace now allowed, so replace XPST0003 by by result"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[<foo>{processing-instruction # div  {}}</foo>]]></test>
       <result>
-         <error code="XPST0003"/>
+         <assert-xml><![CDATA[<foo><?div?></foo>]]></assert-xml>
       </result>
    </test-case>
    

--- a/prod/Literal.xml
+++ b/prod/Literal.xml
@@ -2325,12 +2325,13 @@ line2</assert-string-value>
    <test-case name="Literals-40-925" covers-40="PR1976 PR1982">
       <description> QName literals - disallowed whitespace</description>
       <created by="Michael Kay" on="2025-05-06"/>
+      <modified by="Gunther Rademacher" on="2025-06-24" change="whitespace now allowed, so replace XPST0003 by by result"/>
       <dependency type="spec" value="XQ40+ XP40+"/>
       <test>
          namespace-uri-from-QName( # Q{http://www.example.com/ns}local )
       </test>
       <result>
-         <error code="XPST0003"/>
+         <assert-eq>"http://www.example.com/ns"</assert-eq>
       </result>
    </test-case>
 
@@ -2349,12 +2350,13 @@ line2</assert-string-value>
    <test-case name="Literals-40-926" covers-40="PR1976">
       <description> QName literals - disllowed comments</description>
       <created by="Michael Kay" on="2025-05-06"/>
+      <modified by="Gunther Rademacher" on="2025-06-24" change="whitespace now allowed, so replace XPST0003 by by result"/>
       <dependency type="spec" value="XQ40+ XP40+"/>
       <test>
          namespace-uri-from-QName( #(:improbably:)Q{http://www.example.com/ns}local )
       </test>
       <result>
-         <error code="XPST0003"/>
+         <assert-eq>"http://www.example.com/ns"</assert-eq>
       </result>
    </test-case>
    


### PR DESCRIPTION
After today's merge of qt4cg/qtspecs#2064, whitespace is allowed in `QNameLiteral` and `MarkedNCName` between `#` and the name to follow. 

This change adapts six tests that have whitespace in these places and used to expect a syntax error `XPST0003`.