### PR TITLE
Restore closing tag that got lost with recent merge

### DIFF
--- a/fn/sort-by.xml
+++ b/fn/sort-by.xml
@@ -139,6 +139,7 @@
       <description>One-argument sort-by where input is not simple </description>
       <created by="Josh Spiegel" on="2015-08-10"/>
       <modified by="Debbie Lockett" on="2015-08-12" change="Added XQuery dependency"/>
+      <modified by="Gunther Rademacher" on="2025-07-01" change="restore closing tag that got lost with recent merge"/>
       <dependency type="spec" value="XQ31+"/>
       <test><![CDATA[
         <turtles>
@@ -146,6 +147,7 @@
           <name>Raphael</name>
           <name>Donatello</name>
           <name>Michelangelo</name>
+        </turtles>
         !sort-by(*, ())!data()
       ]]></test>
       <result>


### PR DESCRIPTION
In a recent merge (9f42ab2dc53b4899f7477404945e6a49986ca322), a closing tag got lost, this change restores it.