### PR TITLE
Test case `let-arr-015`: avoid skipping of type check by having `$z` contribute to the result

### DIFF
--- a/prod/LetClause.xml
+++ b/prod/LetClause.xml
@@ -2741,8 +2741,9 @@
    <test-case name="let-arr-015" covers-40="PR2055">
       <description> Deconstruct array. </description>
       <created by="Michael Kay" on="2025-06-29"/>
+      <modified by="Gunther Rademacher" on="2025-07-02" change="avoid skipping of type check by having $z contribute to the result"/>
       <dependency type="spec" value="XQ40+ XP40+"/>
-      <test>let $[ $x as xs:integer, $y as xs:string, $z as xs:date ]:= [1,"two"] return ($x, $y)</test>
+      <test>let $[ $x as xs:integer, $y as xs:string, $z as xs:date ]:= [1,"two"] return ($x, $y, $z)</test>
       <result>
          <error code="XPTY0004"/>
       </result>


### PR DESCRIPTION
Test case `let-arr-015` expects a type error `XPTY0004` from this expression,

```xquery
let $[ $x as xs:integer, $y as xs:string, $z as xs:date ]:= [1,"two"] return ($x, $y)
```

because `$z` cannot be bound to an empty sequence.

However my understanding is that the processor is free to skip the corresponding type check, because `$z` does not contribute to the result. So this change adds it accordingly.