### PR TITLE
Test fixes related to built-in record types

### DIFF
--- a/fn/random-number-generator.xml
+++ b/fn/random-number-generator.xml
@@ -397,6 +397,8 @@ r:random-sequence(200)]]></test>
     <test-case name="fn-random-number-generator-35">
         <description>Test for 'next' generator</description>
         <created by="Tim Mills" on="2016-06-13"/>
+        <modified by="Gunther Rademacher" on="2025-07-15" change="add dependency"/>
+        <dependency type="spec" value="XP31 XQ31"/>
         <test>fn:random-number-generator()?next</test>
         <result>
             <all-of>
@@ -405,10 +407,26 @@ r:random-sequence(200)]]></test>
             </all-of>  
         </result>
     </test-case>
-    
+
+    <test-case name="fn-random-number-generator-35a">
+        <description>Spawned from -35, function returns extensible record in 4.0</description>
+        <created by="Gunther Rademacher" on="2025-07-15"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
+        <test>fn:random-number-generator()?next</test>
+        <result>
+            <all-of>
+                <assert-type>function(*)</assert-type>
+                <assert-type>function() as map(xs:anyAtomicType, item()*)</assert-type>
+                <assert-type>function() as fn:random-number-generator-record</assert-type>
+            </all-of>
+        </result>
+    </test-case>
+
     <test-case name="fn-random-number-generator-36">
         <description>Test for 'next' generator</description>
         <created by="Tim Mills" on="2016-06-13"/>
+        <modified by="Gunther Rademacher" on="2025-07-15" change="add dependency"/>
+        <dependency type="spec" value="XP31 XQ31"/>
         <test>fn:random-number-generator( () )?next</test>
         <result>
             <all-of>
@@ -417,10 +435,26 @@ r:random-sequence(200)]]></test>
             </all-of>  
         </result>
     </test-case>
-    
+
+    <test-case name="fn-random-number-generator-36a">
+        <description>Spawned from -36, function returns extensible record in 4.0</description>
+        <created by="Gunther Rademacher" on="2025-07-15"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
+        <test>fn:random-number-generator( () )?next</test>
+        <result>
+            <all-of>
+                <assert-type>function(*)</assert-type>
+                <assert-type>function() as map(xs:anyAtomicType, item()*)</assert-type>
+                <assert-type>function() as fn:random-number-generator-record</assert-type>
+            </all-of>
+        </result>
+    </test-case>
+
     <test-case name="fn-random-number-generator-37">
         <description>Test for 'next' generator</description>
         <created by="Tim Mills" on="2016-06-13"/>
+        <modified by="Gunther Rademacher" on="2025-07-15" change="add dependency"/>
+        <dependency type="spec" value="XP31 XQ31"/>
         <test>fn:random-number-generator( 0 )?next</test>
         <result>
             <all-of>
@@ -429,7 +463,21 @@ r:random-sequence(200)]]></test>
             </all-of>  
         </result>
     </test-case>
-    
+
+    <test-case name="fn-random-number-generator-37a">
+        <description>Spawned from -37, function returns extensible record in 4.0</description>
+        <created by="Gunther Rademacher" on="2025-07-15"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
+        <test>fn:random-number-generator( 0 )?next</test>
+        <result>
+            <all-of>
+                <assert-type>function(*)</assert-type>
+                <assert-type>function() as map(xs:anyAtomicType, item()*)</assert-type>
+                <assert-type>function() as fn:random-number-generator-record</assert-type>
+            </all-of>
+        </result>
+    </test-case>
+
     <test-case name="fn-random-number-generator-38">
         <description>'next' function</description>
         <created by="Tim Mills" on="2016-06-13"/>

--- a/prod/SequenceType.xml
+++ b/prod/SequenceType.xml
@@ -219,11 +219,12 @@
    <test-case name="built-in-record-type-003" covers-40="PR1991">
       <description> Test existence of built-in-record type fn:parsed-csv-structure-record. </description>
       <created by="Michael Kay" on="2025-05-29"/>
+      <modified by="Gunther Rademacher" on="2025-07-15" change="change get result type from xs:string? to xs:string"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>{'columns':('a','b','c'), 
              'column-index':{'a':1, 'b':2, 'c':3}, 
              'rows':(["p","q","r"], ["s", "t", "u"]), 
-             'get':fn($row as xs:positiveInteger, $col as (xs:positiveInteger|xs:string)) as xs:string? {"banana"} 
+             'get':fn($row as xs:positiveInteger, $col as (xs:positiveInteger|xs:string)) as xs:string {"banana"}
              } instance of fn:parsed-csv-structure-record</test>
       <result>
          <assert-true/>


### PR DESCRIPTION
While working on built-in record types, I found that these tests need to be fixed:

-  `built-in-record-type-003`

   This supplies a `get` function returning `xs:string?`, but this does not match with `fn:parsed-csv-structure-record` which asks for `get` to return `xs:string`
   
- `fn-random-number-generator-35` through `fn-random-number-generator-37`

   These check a function item returning `fn:random-number-generator-record` using

   ```xml
   <assert-type>function() as map(xs:string, item())</assert-type>
   ```

  However `fn:random-number-generator-record` is extensible, so it should be either or both of
  
  ```xml
  <assert-type>function() as map(xs:anyAtomicType, item()*)</assert-type>
  <assert-type>function() as fn:random-number-generator-record</assert-type>
  ```