### PR TITLE
Adapt tests to changed list of reserved keywords

### DIFF
--- a/prod/FunctionCall.xml
+++ b/prod/FunctionCall.xml
@@ -2230,7 +2230,8 @@
    <test-case name="function-call-reserved-function-names-007">
       <description>Check that reserved function name item is handled correctly. </description>
       <created by="Tim Mills" on="2013-01-24"/>
-      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XQ10+"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>
 	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function local:item($arg) { fn:true() };
@@ -2238,21 +2239,6 @@
       </test>
       <result>
          <error code="XPST0003" />
-      </result>
-   </test-case>
-
-   <test-case name="function-call-reserved-function-names-007a">
-      <description>Keyword is not reserved anymore with version 4.0.</description>
-      <created by="Christian Gruen" on="2024-05-22"/>
-      <modified by="Gunther Rademacher" on="2025-02-27" change="Removed XP40+ dependency"/>
-      <dependency type="spec" value="XQ40+"/>
-      <test>
-	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
-	declare function local:item($arg) { fn:true() };
-	item(1)
-      </test>
-      <result>
-         <assert-true/>
       </result>
    </test-case>
 
@@ -2687,10 +2673,11 @@
 
    <test-case name="function-call-reserved-function-names-039">
       <description>Check that reserved function name array is handled correctly. 
-        (Reserved in 3.1, unreserved again in 4.0)</description>
+        (Reserved since 3.1)</description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XQ10 XQ30 XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency tp XQ10 XQ30"/>
+      <dependency type="spec" value="XQ10 XQ30"/>
       <test>
 	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function local:array() { fn:true() };
@@ -2705,7 +2692,8 @@
       <description>Check that reserved function name array is handled correctly. </description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XQ31"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XQ31+"/>
+      <dependency type="spec" value="XQ31+"/>
       <test>
 	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function local:array() { fn:true() };
@@ -2720,7 +2708,8 @@
       <description>Check that reserved function name array is handled correctly. </description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XP20 XP30 XQ10 XQ30 XP40+ XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP20 XP30 XQ10 XQ30"/>
+      <dependency type="spec" value="XP20 XP30 XQ10 XQ30"/>
       <test>
 	array()
       </test>
@@ -2733,7 +2722,8 @@
       <description>Check that reserved function name array is handled correctly. </description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XP31 XQ31"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP31+ XQ31+"/>
+      <dependency type="spec" value="XP31+ XQ31+"/>
       <test>
 	array()
       </test>
@@ -2744,10 +2734,11 @@
 
    <test-case name="function-call-reserved-function-names-043">
       <description>Check that reserved function name map is handled correctly. 
-         (Reserved in 3.1, unreserved again in 4.0)</description>
+         (Reserved since 3.1)</description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XQ10 XQ30 XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XQ10 XQ30"/>
+      <dependency type="spec" value="XQ10 XQ30"/>
       <test>
 	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function local:map() { fn:true() };
@@ -2755,6 +2746,21 @@
       </test>
       <result>
          <assert-true />
+      </result>
+   </test-case>
+
+   <test-case name="function-call-reserved-function-names-043a">
+      <description>Check that reserved function name map is handled correctly. 
+         (Reserved since 3.1)</description>
+      <created by="Gunther Rademacher" on="2025-08-06"/>
+      <dependency type="spec" value="XQ31+"/>
+      <test>
+	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
+	declare function local:map() { fn:true() };
+	map()
+      </test>
+      <result>
+         <error code="XPST0003" />
       </result>
    </test-case>
 
@@ -2777,7 +2783,8 @@
       <description>Check that reserved function name map is handled correctly. </description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XP20 XP30 XP40+ XQ10 XQ30 XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP20 XP30 XQ10 XQ30"/>
+      <dependency type="spec" value="XP20 XP30 XQ10 XQ30"/>
       <test>
 	map()
       </test>
@@ -2790,7 +2797,8 @@
       <description>Check that reserved function name map is handled correctly. </description>
       <created by="Tim Mills" on="2015-10-14"/>
       <modified by="Michael Kay" on="2023-07-18" change="changed for 4.0"/>
-      <dependency type="spec" value="XP31 XQ31"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP31+ XQ31+"/>
+      <dependency type="spec" value="XP31+ XQ31+"/>
       <test>
 	map()
       </test>

--- a/prod/FunctionDecl.xml
+++ b/prod/FunctionDecl.xml
@@ -1965,7 +1965,8 @@
    <test-case name="function-decl-reserved-function-names-016">
       <description>Check that reserved function name item is handled correctly. </description>
       <created by="Tim Mills" on="2013-01-24"/>
-      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XQ10+"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>
 	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function item() { fn:true() };
@@ -1973,20 +1974,6 @@
       </test>
       <result>
          <error code="XPST0003" />
-      </result>
-   </test-case>
-
-   <test-case name="function-decl-reserved-function-names-016a">
-      <description>Keyword is not reserved anymore with version 4.0.</description>
-      <created by="Christian Gruen" on="2024-05-22"/>
-      <dependency type="spec" value="XQ40+"/>
-      <test>
-	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
-	declare function item() { fn:true() };
-	local:item()
-      </test>
-      <result>
-         <assert-true/>
       </result>
    </test-case>
 

--- a/prod/NamedFunctionRef.xml
+++ b/prod/NamedFunctionRef.xml
@@ -4750,23 +4750,13 @@
    <test-case name="named-function-ref-reserved-function-names-008">
       <description>Check that reserved function name item is handled correctly. </description>
       <created by="Tim Mills" on="2013-01-24"/>
-      <dependency type="spec" value="XP30 XQ30 XP31 XQ31"/>
+      <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP30+ XQ30+"/>
+      <dependency type="spec" value="XP30+ XQ30+"/>
       <test>
 	fn:exists(item#0)
       </test>
       <result>
          <error code="XPST0003" />
-      </result>
-   </test-case>
-
-   <test-case name="named-function-ref-reserved-function-names-008a">
-      <description>Keyword is not reserved anymore with version 4.0.</description>
-      <created by="Christian Gruen" on="2024-05-22"/>
-      <test>
-	fn:exists(item#0)
-      </test>
-      <result>
-         <error code="XPST0017" />
       </result>
    </test-case>
 
@@ -4863,7 +4853,8 @@
   <test-case name="named-function-ref-reserved-function-names-017" covers="array-general">
     <description>Check that reserved function name array is handled correctly. </description>
     <created by="Debbie Lockett" on="2015-10-13"/>
-    <dependency type="spec" value="XP31 XQ31"/>
+    <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP31+ XQ31+"/>
+    <dependency type="spec" value="XP31+ XQ31+"/>
     <test>
       fn:exists(array#0)
     </test>
@@ -4871,23 +4862,12 @@
       <error code="XPST0003" />
     </result>
   </test-case>
-  
-  <test-case name="named-function-ref-reserved-function-names-017a">
-    <description>Keyword is not reserved anymore with version 4.0.</description>
-    <created by="Christian Gruen" on="2024-05-22"/>
-    <dependency type="spec" value="XP40+ XQ40+"/>
-    <test>
-      fn:exists(array#0)
-    </test>
-    <result>
-      <error code="XPST0017" />
-    </result>
-  </test-case>
-  
+
   <test-case name="named-function-ref-reserved-function-names-018" covers="map-general">
     <description>Check that reserved function name map is handled correctly. </description>
     <created by="Debbie Lockett" on="2015-10-13"/>
-    <dependency type="spec" value="XP31 XQ31"/>
+    <modified by="Gunther Rademacher" on="2025-08-06" change="set dependency to XP31+ XQ31+"/>
+    <dependency type="spec" value="XP31+ XQ31+"/>
     <test>
       fn:exists(map#0)
     </test>
@@ -4895,19 +4875,7 @@
       <error code="XPST0003" />
     </result>
   </test-case>
-  
-  <test-case name="named-function-ref-reserved-function-names-018a">
-    <description>Keyword is not reserved anymore with version 4.0.</description>
-    <created by="Christian Gruen" on="2024-05-22"/>
-    <dependency type="spec" value="XP40+ XQ40+"/>
-    <test>
-      fn:exists(map#0)
-    </test>
-    <result>
-      <error code="XPST0017" />
-    </result>
-  </test-case>
-  
+
   <test-case name="named-function-ref-function-arity-901">
     <description>Attempts to lookup a context-dependent function when there is no context item. QT4 issue 894</description>
     <created by="Michael Kay" on="2023-12-13"/>


### PR DESCRIPTION
qt4cg/qtspecs#2083 has changed the list of reserved function names. This change adapts a number of tests accordingly.