### PR TITLE
Remove XP40+ dependency from tests using XQuery-only constructs

### DIFF
--- a/op/node-after.xml
+++ b/op/node-after.xml
@@ -462,7 +462,8 @@
    <test-case name="follows-412" covers-40="PR2130">
       <description> Use "follows" spelling of operator </description>
       <created by="Michael Kay" on="2025-07-29"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>   
+      <modified by="Gunther Rademacher" on="2025-08-07" change="set dependency to XQ40+"/>
+     <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
       	let $node := <a> <b/> <c/> </a> 
       	return not(exactly-one($node/b[1]) follows exactly-one($node/c[1]))
@@ -475,7 +476,8 @@
    <test-case name="follows-413" covers-40="PR2130">
       <description> Use "follows" spelling of operator </description>
       <created by="Michael Kay" on="2025-07-29"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>   
+      <modified by="Gunther Rademacher" on="2025-08-07" change="set dependency to XQ40+"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
       	let $node := <a> <b/> <c/> </a> 
       	return not(not(exactly-one($node/b[1]) follows exactly-one($node/c[1])))

--- a/op/node-before.xml
+++ b/op/node-before.xml
@@ -518,7 +518,8 @@
    <test-case name="precedes-412" covers-40="PR2130">
       <description> test node before operator </description>
       <created by="Michael Kay" on="2025-07-29"/>
-      <dependency type="spec" value="XP40+ XQ40+"/> 
+      <modified by="Gunther Rademacher" on="2025-08-07" change="set dependency to XQ40+"/>
+      <dependency type="spec" value="XQ40+"/> 
       <test><![CDATA[
       	let $node := <a> <b/> <c/> </a> 
       	return not(exactly-one($node/b[1]) precedes exactly-one($node/c[1]))
@@ -532,7 +533,8 @@
       <description> test node before operator </description>
       <description> test node before operator </description>
       <created by="Michael Kay" on="2025-07-29"/>
-      <dependency type="spec" value="XP40+ XQ40+"/> 
+      <modified by="Gunther Rademacher" on="2025-08-07" change="set dependency to XQ40+"/>
+      <dependency type="spec" value="XQ40+"/> 
       <test><![CDATA[
       	let $node := <a> <b/> <c/> </a> 
       	return not(not(exactly-one($node/b[1]) precedes exactly-one($node/c[1])))

--- a/prod/MapConstructor.xml
+++ b/prod/MapConstructor.xml
@@ -198,7 +198,8 @@
    <test-case name="MapConstructor-016a" covers-40="PR2094">
       <description>map entry can be an ExprSingle</description>
       <created by="Christian Gruen" on="2025-07-17" change="Syntax changed"/>
-      <dependency type="spec" value="XQ40+ XP40+"/>
+      <modified by="Gunther Rademacher" on="2025-08-07" change="set dependency to XQ40+"/>
+      <dependency type="spec" value="XQ40+"/>
       <environment ref="map"/>
       <test><![CDATA[declare namespace b = "http://b.com"; map:size(<a><b:b>x</b:b></a>/map{b:b})]]></test>
       <result>


### PR DESCRIPTION
A number of new tests are marked with dependency `XP40+ XQ40+`, but they use direct element constructors that are not available in XPath. This change thus removes the `XP40+` dependency. 