### PR TITLE
Adapt test to removal of full-with operator

### DIFF
--- a/op/pipeline.xml
+++ b/op/pipeline.xml
@@ -190,9 +190,10 @@
    <test-case name="pipeline-23" covers-40="PR1810">
       <description>Pipeline operator written with wide angle bracket</description>
       <created by="Michael Kay" on="2025-02-17"/>
+      <modified by="Gunther Rademacher" on="2025-08-10" change="full-width form is no longer supported"/>
       <test>42 -＞ .</test>
       <result>
-         <assert-eq>42</assert-eq>
+         <error code="XPST0003"/>
       </result>
    </test-case>
 


### PR DESCRIPTION
The tests have been mostly adapted to the removal of the operators with full-width less-than or greater-than signs, but `pipeline-23` still expects one to succeed, so changing it to expect a syntax error instead.