### PR TITLE
Fix expectation of `is-not-205`

### DIFF
--- a/op/is-not-same-node.xml
+++ b/op/is-not-same-node.xml
@@ -366,13 +366,14 @@
    </test-case>
 
    <test-case name="is-not-205">
-      <description> exactly-one() to is, that fails. Inferrence may conclude that it will always evaluate to false, so that is-not valid as well. </description>
+      <description> exactly-one() to is-not, that fails. Inferrence may conclude that it will always evaluate to false, so that is valid as well. </description>
       <created by="Frans Englich" on="2007-11-26"/>
+      <modified by="Gunther Rademacher" on="2025-08-13" change="expectation was incorrectly set to true when test was created from K2-NodeSame-5"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[empty(exactly-one(<e/>/*) is-not exactly-one(<e/>/*))]]></test>
       <result>
          <any-of>
-            <assert-true/>
+            <assert-false/>
             <error code="FORG0005"/>
          </any-of>
       </result>


### PR DESCRIPTION
Test  case `is-not-205` was created recently from `K2-NodeSame-5` as follows

 - the `is` operator was changed to `is-not`,
 - the expectation was changed from `assert-false` to `assert-true`,
 
 yielding this:

```xml
      <test><![CDATA[empty(exactly-one(<e/>/*) is-not exactly-one(<e/>/*))]]></test>
      <result>
         <any-of>
            <assert-true/>
            <error code="FORG0005"/>
         </any-of>
      </result>
```

However the result does not depend on the evaluation of the `is-not` operator, but on the fact that it cannot return an empty result when applied to two single item operands. So changing `assert-true` to `assert-false`, as in `K2-NodeSame-5`.