### PR TITLE
Adapt tests to changed syntax of `KeySpecifier`

### DIFF
--- a/prod/Literal.xml
+++ b/prod/Literal.xml
@@ -2172,12 +2172,13 @@ line2</assert-string-value>
    </test-case>
    
    <test-case name="Literals-40-909" covers-40="PR433">
-      <description> hex literals not allowed on rhs of lookup </description>
+      <description> hex literals allowed on rhs of lookup </description>
       <created by="Michael Kay" on="2023-04-07"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="hex literal now allowed"/>
       <dependency type="spec" value="XQ40+ XP40+"/>
       <test>[1,2,3]?0x1</test>
       <result>
-         <error code="XPST0003"/>
+         <assert-eq>1</assert-eq>
       </result>
    </test-case>
    

--- a/prod/Lookup.xml
+++ b/prod/Lookup.xml
@@ -179,13 +179,24 @@
    <test-case name="Lookup-018">
       <description>Decimal literal not allowed</description>
       <created by="Michael Kay" on="2014-11-27"/>
-      <dependency type="spec" value="XP31+ XQ31+"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XP31 XQ31"/>
       <test>(['a', 'b', 'c'], ['b', 'c', 'd'], ['e', 'f', 'b'])[.?1.0 = 'a']</test>
       <result>
          <error code="XPST0003"/>
       </result>
    </test-case>
-   
+
+   <test-case name="Lookup-018a">
+      <description>Decimal literal allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-08-19"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>(['a', 'b', 'c'], ['b', 'c', 'd'], ['e', 'f', 'b'])[.?1.0 = 'a']</test>
+      <result>
+         <assert-deep-eq>['a', 'b', 'c']</assert-deep-eq>
+      </result>
+   </test-case>
+
    <test-case name="Lookup-019">
       <description>Decimal literal not allowed in parentheses</description>
       <created by="Michael Kay" on="2014-11-27"/>
@@ -522,13 +533,24 @@
    <test-case name="Lookup-118">
       <description>Decimal literal not allowed</description>
       <created by="Michael Kay" on="2014-11-27"/>
-      <dependency type="spec" value="XP31+ XQ31+"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XP31 XQ31"/>
       <test>(['a', 'b', 'c'], ['b', 'c', 'd'], ['e', 'f', 'b'])?1.0 </test>
       <result>
          <error code="XPST0003"/>
       </result>
    </test-case>
-   
+
+   <test-case name="Lookup-118a">
+      <description>Decimal literal allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-08-19"/>
+      <dependency type="spec" value="XP31+ XQ31+"/>
+      <test>(['a', 'b', 'c'], ['b', 'c', 'd'], ['e', 'f', 'b'])?1.0 </test>
+      <result>
+         <assert-deep-eq>'a', 'b', 'e'</assert-deep-eq>
+      </result>
+   </test-case>
+
    <test-case name="Lookup-119">
       <description>Decimal literal not allowed in parentheses</description>
       <created by="Michael Kay" on="2014-11-27"/>
@@ -836,13 +858,24 @@
    <test-case name="Lookup-163">
       <description>Decimal literal not allowed for maps</description>
       <created by="Debbie Lockett" on="2015-07-17"/>
-      <dependency type="spec" value="XP31+ XQ31+"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XP31 XQ31"/>
       <test>(map{1.1:1, 2.2:2, 3.3:3},  map{1.1:2, 2.2:3, 3.3:4})?2.2 </test>
       <result>
          <error code="XPST0003"/>
       </result>
    </test-case>
-   
+
+   <test-case name="Lookup-163a">
+      <description>Decimal literal allowed for maps in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-08-19"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>(map{1.1:1, 2.2:2, 3.3:3},  map{1.1:2, 2.2:3, 3.3:4})?2.2 </test>
+      <result>
+         <assert-deep-eq>2, 3</assert-deep-eq>
+      </result>
+   </test-case>
+
    <test-case name="Lookup-164">
       <description>Decimal literal allowed in parentheses for maps</description>
       <created by="Debbie Lockett" on="2015-07-17"/>

--- a/prod/UnaryLookup.xml
+++ b/prod/UnaryLookup.xml
@@ -181,13 +181,24 @@
       <description>Decimal literal not allowed</description>
       <created by="Michael Kay" on="2014-11-27"/>
       <modified by="Michael Dyck" on="2014-12-10" change="change expected error from XPST0001 to XPST0003"/>
-      <dependency type="spec" value="XP31+ XQ31+"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XP31 XQ31"/>
       <test>(['a', 'b', 'c'], ['b', 'c', 'd'], ['e', 'f', 'b'])[?1.0 = 'a']</test>
       <result>
          <error code="XPST0003"/>
       </result>
    </test-case>
-   
+
+   <test-case name="UnaryLookup-018a">
+      <description>Decimal literal allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-08-19"/>
+      <dependency type="spec" value="XP40 XQ40"/>
+      <test>(['a', 'b', 'c'], ['b', 'c', 'd'], ['e', 'f', 'b'])[?1.0 = 'a']</test>
+      <result>
+         <assert-deep-eq>['a', 'b', 'c']</assert-deep-eq>
+      </result>
+   </test-case>
+
    <test-case name="UnaryLookup-019">
       <description>Decimal literal not allowed in parentheses</description>
       <created by="Michael Kay" on="2014-11-27"/>
@@ -352,13 +363,24 @@
    <test-case name="UnaryLookup-047">
       <description>Decimal literal not allowed for maps</description>
       <created by="Debbie Lockett" on="2015-07-17"/>
-      <dependency type="spec" value="XP31+ XQ31+"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XP31 XQ31"/>
       <test>(map{1.1:1, 2.2:2, 3.3:3},  map{1.1:2, 2.2:3, 3.3:4})[?2.2 = 3]</test>
       <result>
          <error code="XPST0003"/>
       </result>
    </test-case>
-   
+
+   <test-case name="UnaryLookup-047a">
+      <description>Decimal literal allowed for maps in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-08-19"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>(map{1.1:1, 2.2:2, 3.3:3},  map{1.1:2, 2.2:3, 3.3:4})[?2.2 = 3]</test>
+      <result>
+         <assert-deep-eq>map{1.1:2, 2.2:3, 3.3:4}</assert-deep-eq>
+      </result>
+   </test-case>
+
    <test-case name="UnaryLookup-048">
       <description>Decimal literal allowed in parentheses for maps</description>
       <created by="Debbie Lockett" on="2015-07-17"/>


### PR DESCRIPTION
`KeySpecifier` has recently ([e26b54c](https://github.com/qt4cg/qtspecs/commit/e26b54c337ea4b1eea7d194a4555ca5218729589)) been extended to allow any literal, and context value references. This change adapts a number of tests accordingly. 