### PR TITLE
Remove XP40+ dependency from tests using XQuery-only constructs

### DIFF
--- a/app/UseCaseJSONiq.xml
+++ b/app/UseCaseJSONiq.xml
@@ -87,7 +87,8 @@
    <test-case name="JSONiq-1.1.2-a">
       <description>Grouping</description>
       <created by="Michael Kay" on="2025-08-13"/>
-      <dependency type="spec" value="XQ40+ XP40+"/>      
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XQ40+"/>      
       <test>
          let $sales := (
             { "product" : "broiler", "store number" : 1, "quantity" : 20  },
@@ -126,7 +127,8 @@
    <test-case name="JSONiq-1.1.2-b">
       <description>Grouping</description>
       <created by="Michael Kay" on="2025-08-13"/>
-      <dependency type="spec" value="XQ40+ XP40+"/>      
+      <modified by="Gunther Rademacher" on="2025-08-19" change="changed dependency"/>
+      <dependency type="spec" value="XQ40+"/>      
       <test>
          let $sales := (
             { "product" : "broiler", "store number" : 1, "quantity" : 20  },


### PR DESCRIPTION
A number of new tests are marked with dependency `XP40+ XQ40+`, but they use `group by`, which is not available in XPath. This change thus removes the `XP40+` dependency.