### PR TITLE
Fix syntax errors in new tests

### DIFF
--- a/fn/innermost.xml
+++ b/fn/innermost.xml
@@ -754,8 +754,9 @@
    <test-case name="fn-innermost-101" covers-40="PR2149">
       <description>Apply to JNodes</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="removed extraneous curly brace"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test><![CDATA[ map{'a':4, 'b':map{'b':12}}, 'c':5}//b => innermost() => jnode-content() ]]></test>
+      <test><![CDATA[ map{'a':4, 'b':map{'b':12}, 'c':5}//b => innermost() => jnode-content() ]]></test>
       <result>
          <assert-eq>12</assert-eq>
       </result>
@@ -764,8 +765,9 @@
    <test-case name="fn-innermost-102" covers-40="PR2149">
       <description>Apply to JNodes</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="removed extraneous curly brace"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test><![CDATA[ map{'a':4, 'b':map{'b':12}}, 'c':map{'b':13}}//b => innermost() => jnode-content() ]]></test>
+      <test><![CDATA[ map{'a':4, 'b':map{'b':12}, 'c':map{'b':13}}//b => innermost() => jnode-content() ]]></test>
       <result>
          <assert-deep-eq>12, 13</assert-deep-eq>
       </result>

--- a/fn/outermost.xml
+++ b/fn/outermost.xml
@@ -753,8 +753,9 @@
    <test-case name="fn-outermost-101" covers-40="PR2149">
       <description>Apply to JNodes</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="removed extraneous curly brace"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test><![CDATA[ map{'a':4, 'b':map{'b':12}}, 'c':5}//b => outermost() => jnode-content()]]></test>
+      <test><![CDATA[ map{'a':4, 'b':map{'b':12}, 'c':5}//b => outermost() => jnode-content()]]></test>
       <result>
          <assert-deep-eq>map{'b':12}</assert-deep-eq>
       </result>
@@ -763,8 +764,9 @@
    <test-case name="fn-outermost-102" covers-40="PR2149">
       <description>Apply to JNodes</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-08-19" change="removed extraneous curly brace"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
-      <test><![CDATA[ map{'a':4, 'b':map{'b':12}}, 'c':map{'b':13}}//b => outermost() => jnode-content()]]></test>
+      <test><![CDATA[ map{'a':4, 'b':map{'b':12}, 'c':map{'b':13}}//b => outermost() => jnode-content()]]></test>
       <result>
          <assert-deep-eq>map{'b':12}, 13</assert-deep-eq>
       </result>


### PR DESCRIPTION
A number of new tests have syntax errors due to extraneous curly braces. These are removed here.