### PR TITLE
Allow alternate error code for `MappingArrow-113`

### DIFF
--- a/prod/MappingArrow.xml
+++ b/prod/MappingArrow.xml
@@ -641,10 +641,14 @@
   <test-case name="MappingArrow-113" covers-40="PR1763 PR1830">
     <description>Dynamic function call of function returned by static function call</description>
     <created by="Michael Kay" on="2025-02-18"/>
+    <modified by="Gunther Rademacher" on="2025-08-27" change="allow XPST0017"/>
     <dependency type="spec" value="XP40+ XQ40+"/>
     <test>-3 =!> function-lookup(xs:QName('fn:abs'), 1)()</test>
     <result>
-      <error code="XPST0003"/>
+      <any-of>
+        <error code="XPST0003"/>
+        <error code="XPST0017"/>
+      </any-of>
     </result>
   </test-case>
 


### PR DESCRIPTION
Test case [`MappingArrow-113`](https://github.com/qt4cg/qt4tests/blob/819a81c261809102098c2620b547d9628fdc87cf/prod/MappingArrow.xml#L641-L649) asks for an `XPST0003` syntax error to occur on the second-to-last character, an opening parenthesis, in this expression:

```xquery
-3 =!> function-lookup(xs:QName('fn:abs'), 1)()
```
 
However it is possible to detect an error already earlier: a static function call following the mapping arrow operator takes its first argument from the left hand side expression of the operator, making up a wrong number of arguments to `fn:function-lookup`. This would result in error `XPST0017` which thus should be allowed alternatively in this test case.