### PR TITLE
Ignore the sandpit files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.log*
+/results/sandpit

--- a/results/sandpit/put-001.xml
+++ b/results/sandpit/put-001.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><test it="now"/>

--- a/results/sandpit/put-009.xml
+++ b/results/sandpit/put-009.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><test/>

--- a/results/sandpit/put-013a.xml
+++ b/results/sandpit/put-013a.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><test-a/>

--- a/results/sandpit/put-013b.xml
+++ b/results/sandpit/put-013b.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><test-b/>

--- a/results/sandpit/put-101.xml
+++ b/results/sandpit/put-101.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><test it="2025-02-02Z"/>


### PR DESCRIPTION
It irks me that running the test suite changes files that are under version control.

I did a little investigating and *I think* that all of the `sandpit` files are created by tests and none are read before they're created (meaning they don't need to be in the repository).

This PR removes them and adds `results/sandpit` to the `.gitignore` file.

If anyone concurs with my analysis, please feel free to merge this PR. (I haven't properly tested it yet because it's not convenient to do so just at the moment.)