### PR TITLE
Change method call operator from `?>` to `=?>`

### DIFF
--- a/prod/MethodCall.xml
+++ b/prod/MethodCall.xml
@@ -7,9 +7,10 @@
    <test-case name="method-001">
       <description>simple case</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':fn{?length × ?width}}
-         return $rectangle ?> area()
+         return $rectangle =?> area()
       </test>
       <result>
          <assert-eq>6</assert-eq>
@@ -19,6 +20,7 @@
    <test-case name="method-002">
       <description>more complex case with params and chaining</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length': 3, 
                             'width': 2, 
@@ -28,7 +30,7 @@
                                            => map:put('width', $rect?width × $scale)
                                       }
                            }
-         return $rectangle ?> resize(2) ?> area()
+         return $rectangle =?> resize(2) =?> area()
       </test>
       <result>
          <assert-eq>24</assert-eq>
@@ -38,9 +40,10 @@
    <test-case name="method-003">
       <description>empty sequence</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':fn{?length × ?width}}
-         return $rectangle[2] ?> area()
+         return $rectangle[2] =?> area()
       </test>
       <result>
          <assert-empty/>
@@ -50,10 +53,11 @@
    <test-case name="method-004">
       <description>multiple maps</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangles := ({'length':3, 'width':2, 'area':fn{?length × ?width}},
                              {'length':4, 'width':5, 'area':fn{?length × ?width}})
-         return $rectangles ?> area()
+         return $rectangles =?> area()
       </test>
       <result>
          <assert-deep-eq>6, 20</assert-deep-eq>
@@ -63,9 +67,10 @@
    <test-case name="method-005">
       <description>chaining</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $proto := {'add': map:put#3}
-         return $proto ?> add('x', 3) ?> add('y', 4) => map:remove('add')
+         return $proto =?> add('x', 3) =?> add('y', 4) => map:remove('add')
       </test>
       <result>
          <assert-deep-eq>{'x':3, 'y':4}</assert-deep-eq>
@@ -75,11 +80,12 @@
    <test-case name="method-006">
       <description>mutual recursion</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
-         let $proto := {'odd':  fn($map, $n) {$map ?> even($n - 1)},
-                        'even': fn($map, $n) {$n = 0 or $map ?> odd($n - 1)}
+         let $proto := {'odd':  fn($map, $n) {$map =?> even($n - 1)},
+                        'even': fn($map, $n) {$n = 0 or $map =?> odd($n - 1)}
                        }
-         return $proto ?> odd(3)
+         return $proto =?> odd(3)
       </test>
       <result>
          <assert-true/>
@@ -89,9 +95,10 @@
    <test-case name="method-901">
       <description>LHS is not a map</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := [3, 2]
-         return $rectangle ?> area()
+         return $rectangle =?> area()
       </test>
       <result>
          <error code="XPTY0004"/>
@@ -101,9 +108,10 @@
    <test-case name="method-902">
       <description>method does not exist</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':fn{?length × ?width}}
-         return $rectangle ?> perimeter()
+         return $rectangle =?> perimeter()
       </test>
       <result>
          <error code="XPDY0050"/>
@@ -113,9 +121,10 @@
    <test-case name="method-903">
       <description>method is not a function</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':fn{?length × ?width}}
-         return $rectangle ?> length()
+         return $rectangle =?> length()
       </test>
       <result>
          <error code="XPDY0050"/>
@@ -125,9 +134,10 @@
    <test-case name="method-904">
       <description>method is not a single function</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':(fn{?length × ?width}, fn{?length})}
-         return $rectangle ?> area()
+         return $rectangle =?> area()
       </test>
       <result>
          <error code="XPDY0050"/>
@@ -137,9 +147,10 @@
    <test-case name="method-905">
       <description>method does not expect a map as first argument</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':fn:contains#2}
-         return $rectangle ?> area()
+         return $rectangle =?> area()
       </test>
       <result>
          <error code="XPTY0004"/>
@@ -149,9 +160,10 @@
    <test-case name="method-906">
       <description>method has arity zero</description>
       <created by="Michael Kay" on="2025-08-13"/>
+      <modified by="Gunther Rademacher" on="2025-09-20" change="replace ?> operator by =?>"/>
       <test>
          let $rectangle := {'length':3, 'width':2, 'area':math:pi#0}
-         return $rectangle ?> area()
+         return $rectangle =?> area()
       </test>
       <result>
          <error code="XPTY0004"/>


### PR DESCRIPTION
Per qt4cg/qtspecs#2171, the method call operator has changed from `?>` to `=?>`.

This change adapts the tests accordingly.