### PR TITLE
Remove incorrect `XP40+` dependency

### DIFF
--- a/fn/path.xml
+++ b/fn/path.xml
@@ -375,7 +375,8 @@
    <test-case name="path045" covers-40="PR1620">
       <description>path() applied to a parentless attribute node, with namespace for fn:root()</description>
       <created by="Michael Kay" on="2024-12-04"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-09-23" change="remove XP40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>fn:path(attribute name {"fred"},
                 {"namespaces": {"fn": "http://www.w3.org/2005/xpath-functions"}})</test>
       <result>
@@ -569,7 +570,8 @@
    <test-case name="path057" covers-40="PR1886">
       <description>relative path to an attribute of an element root</description>
       <created by="Michael Kay" on="2025-03-25"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
+      <modified by="Gunther Rademacher" on="2025-09-23" change="remove XP40+ dependency"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
          let $doc := <z><z><z><a b="c"/></z></z></z>
          return fn:path($doc//@b, {'origin':$doc, 'lexical':true()})


### PR DESCRIPTION
Two tests have been marked with an `XP40+` dependency, but they are using constructors, that are not available in XPath.