### PR TITLE
Adapt test cases to changed rules for function namespaces

### DIFF
--- a/misc/CombinedErrorCodes.xml
+++ b/misc/CombinedErrorCodes.xml
@@ -2434,10 +2434,22 @@
    <test-case name="XQST0045-1">
       <description> check that bad function declarations are reported correctly </description>
       <created by="Tim Mills" on="2008-05-16"/>
-      <dependency type="spec" value="XQ10+"/>
+      <modified by="Gunther Rademacher" on="2025-10-14" change="changed dependency"/>
+      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
       <test>declare function foo() { 1 }; foo()</test>
       <result>
          <error code="XQST0045"/>
+      </result>
+   </test-case>
+
+
+   <test-case name="XQST0045-1a">
+      <description>Functions in no namespace allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-10-14"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>declare function foo() { 1 }; foo()</test>
+      <result>
+         <assert-eq>1</assert-eq>
       </result>
    </test-case>
 
@@ -2809,11 +2821,24 @@
    <test-case name="XQST0060">
       <description> check that bad context item types are reported correctly </description>
       <created by="Tim Mills" on="2008-05-16"/>
-      <dependency type="spec" value="XQ10+"/>
+      <modified by="Gunther Rademacher" on="2025-10-14" change="changed dependency"/>
+      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
 
       <test>declare default function namespace ""; declare function foo() { 1 }; 1</test>
       <result>
          <error code="XQST0060"/>
+      </result>
+   </test-case>
+
+
+   <test-case name="XQST0060a">
+      <description>Functions in no namespace allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-10-14"/>
+      <dependency type="spec" value="XQ40+"/>
+
+      <test>declare default function namespace ""; declare function foo() { 1 }; 1</test>
+      <result>
+         <assert-eq>1</assert-eq>
       </result>
    </test-case>
 

--- a/prod/AxisStep.xml
+++ b/prod/AxisStep.xml
@@ -5078,13 +5078,24 @@ tour:main()
    <test-case name="K2-Axes-99">
       <description> Use an invalid function declaration(#3).</description>
       <created by="Frans Englich" on="2007-11-26+01:00"/>
-      <dependency type="spec" value="XQ10+"/>
+      <modified by="Gunther Rademacher" on="2025-10-14" change="changed dependency"/>
+      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
       <test>declare function foo() external; 1</test>
       <result>
          <any-of>
             <error code="XQST0045"/>
             <error code="XPST0017"/>
          </any-of>
+      </result>
+   </test-case>
+
+   <test-case name="K2-Axes-99a">
+      <description>Function declaration with no namespace, allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-10-14"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>declare function foo() external; 1</test>
+      <result>
+         <assert-eq>1</assert-eq>
       </result>
    </test-case>
 

--- a/prod/FunctionDecl.xml
+++ b/prod/FunctionDecl.xml
@@ -320,6 +320,8 @@
    <test-case name="function-declaration-023">
       <description> Demonstrate function declaration - negative tests </description>
       <created by="Ravindranath Chennoju" on="2005-08-30"/>
+      <modified by="Gunther Rademacher" on="2025-10-14" change="changed dependency"/>
+      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
       <test>
         declare function foo ($n as xs:integer) { $n };
         foo(4)</test>
@@ -328,6 +330,18 @@
             <error code="XQST0045"/>
             <error code="XPST0017"/>
          </any-of>
+      </result>
+   </test-case>
+
+   <test-case name="function-declaration-023a">
+      <description>Function declaration with no namespace, allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-10-14"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>
+        declare function foo ($n as xs:integer) { $n };
+        foo(4)</test>
+      <result>
+         <assert-eq>4</assert-eq>
       </result>
    </test-case>
 
@@ -345,11 +359,25 @@
    <test-case name="function-declaration-025">
       <description> Function Declaration with no namespace. </description>
       <created by="Carmelo Montanez" on="2006-02-06"/>
+      <modified by="Gunther Rademacher" on="2025-10-14" change="changed dependency"/>
+      <dependency type="spec" value="XQ10 XQ30 XQ31"/>
       <test>declare default function namespace "";
         declare function foo ($n as xs:integer, $m as xs:integer) { $n };
         foo(4, 1)</test>
       <result>
          <error code="XQST0060"/>
+      </result>
+   </test-case>
+
+   <test-case name="function-declaration-025a">
+      <description>Function Declaration with no namespace, allowed in 4.0</description>
+      <created by="Gunther Rademacher" on="2025-10-14"/>
+      <dependency type="spec" value="XQ40+"/>
+      <test>declare default function namespace "";
+        declare function foo ($n as xs:integer, $m as xs:integer) { $n };
+        foo(4, 1)</test>
+      <result>
+         <assert-eq>4</assert-eq>
       </result>
    </test-case>
 
@@ -1888,11 +1916,11 @@
    <test-case name="function-decl-reserved-function-names-010a">
       <description>Keyword is not reserved anymore with version 4.0.</description>
       <created by="Christian Gruen" on="2024-05-22"/>
+      <modified by="Gunther Rademacher" on="2025-10-14" change="function is now in no namespace"/>
       <dependency type="spec" value="XQ40+"/>
       <test>
-	declare default function namespace "http://www.w3.org/2005/xquery-local-functions";
 	declare function empty-sequence() { fn:true() };
-	local:empty-sequence()
+	empty-sequence()
       </test>
       <result>
          <assert-true/>


### PR DESCRIPTION
A number of pre-existing test cases need to be adapted to the new rules for function namespaces.