### PR TITLE
Adapt test case to revised rules for enums

### DIFF
--- a/prod/SequenceType.xml
+++ b/prod/SequenceType.xml
@@ -462,19 +462,20 @@
    <test-case name="built-in-record-type-305" covers-40="PR1991">
       <description> Invalid instance of built-in-record type fn:schema-type-record. </description>
       <created by="Michael Kay" on="2025-05-29"/>
+      <modified by="Gunther Rademacher" on="2025-10-21" change="flip result to true, because 'atomic' is a valid enum instance since #2154"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>{'name':xs:QName('platonic'), 
              'is-simple':true(),
              'base-type':fn() as fn:schema-type-record {atomic-type-annotation(3)},
              'primitive-type':fn() as fn:schema-type-record {atomic-type-annotation(3)},
-             'variety':'atomic', (: wrong, must be an enum :)
+             'variety':'atomic',
              'members':fn() as fn:schema-type-record* {()},
              'simple-content-type':fn() as fn:schema-type-record {atomic-type-annotation(3)},
              'matches':fn($x as xs:anyAtomicType) as xs:boolean {true()},
              'constructor':xs:integer#1
              } instance of fn:schema-type-record</test>
       <result>
-         <assert-false/>
+         <assert-true/>
       </result>
    </test-case>
 


### PR DESCRIPTION
Test case ` built-in-record-type-305` needs to be adapted to the revised (per qt4cg/qtspecs#2154) rules for enumeration types.