### PR TITLE
Adapt test case `graphemes-1177` to Unicode 17

### DIFF
--- a/fn/graphemes.xml
+++ b/fn/graphemes.xml
@@ -9689,9 +9689,13 @@
    <test-case name="graphemes-1177">
       <description>÷ [0.2] UPPER BLADE SCISSORS (Other) × [9.0] ZERO WIDTH JOINER (ZWJ_ExtCccZwj) × [11.0] UPPER BLADE SCISSORS (Other) ÷ [0.3]</description>
       <created by="Joel Kalvesmaki" on="2024-03-11-04:00"/>
+      <modified by="Gunther Rademacher" on="2025-11-04" change="add alternate result because Unicode 17 changes properties of '&#x2701;'"/>
       <test>graphemes("&#x2701;&#x200D;&#x2701;")</test>
       <result>
-         <assert-deep-eq>"&#x2701;&#x200D;&#x2701;"</assert-deep-eq>
+         <any-of>
+            <assert-deep-eq>"&#x2701;&#x200D;&#x2701;"</assert-deep-eq>
+            <assert-deep-eq>"&#x2701;&#x200D;", "&#x2701;"</assert-deep-eq>
+         </any-of>
       </result>
    </test-case>
    <test-case name="graphemes-1178">


### PR DESCRIPTION
Test case `graphemes-1177` fails under Unicode 17 (as is used in ICU4J 78.1) because `U+2701 UPPER BLADE SCISSORS` was removed from the `Extended_Pictographic` property in `emoji-data.txt`:

  - Unicode 16.0: [emoji-data.txt](https://www.unicode.org/Public/16.0.0/ucd/emoji/emoji-data.txt).
  - Unicode 17.0: [emoji-data.txt](https://www.unicode.org/Public/17.0.0/ucd/emoji/emoji-data.txt).

The test previously expected a single grapheme per [UAX #29 GB11](https://www.unicode.org/reports/tr29/#GB11) ("Do not break within ... emoji zwj sequences"). Since `U+2701` no longer has `Extended_Pictographic`, GB11 no longer applies, and two graphemes are now produced.

To maintain compatibility with Unicode 17 and earlier versions, the test now accepts either result.