### PR TITLE
Adapt `DynamicFunctionCall-R-136` to recent change of coercion rules

### DIFF
--- a/prod/DynamicFunctionCall.xml
+++ b/prod/DynamicFunctionCall.xml
@@ -1253,13 +1253,14 @@
       <created by="Michael Kay" on="2024-02-09"/>
       <modified by="Michael Kay" on="2024-04-18" change="new rules say promotion happens here"/>
       <modified by="Gunther Rademacher" on="2024-07-22" change="no coercion from xs:anyURI to enum"/>
+      <modified by="Gunther Rademacher" on="2025-11-12" change="coercion is now defined from xs:anyURI to enum"/>
       <test>
          let $f := function($in as record(x as enum("a", "b", "c"))) as xs:string {
             string($in?x)
          }
          return $f(map{'x':xs:anyURI('a')})</test>
       <result>
-         <error code="XPTY0004"/>
+         <assert-eq>"a"</assert-eq>
       </result>
    </test-case>
    


### PR DESCRIPTION
The coercion rules have changed to allow coercion from `xs:anyURI` to `enum`. Test case `DynamicFunctionCall-136` has been adapted in 2c4f22a. This change adapts test case `DynamicFunctionCall-R-136` as well.