### PR TITLE
Correct expected result in `subtyping-076`

### DIFF
--- a/misc/Subtyping.xml
+++ b/misc/Subtyping.xml
@@ -539,13 +539,14 @@
    <test-case name="subtyping-076" covers-40="PR1604">
       <description>Node types</description>
       <created by="Michael Kay" on="2024-11-29"/>
+      <modified by="Gunther Rademacher" on="2025-12-03" change="change expected result to true"/>
       <module uri="http://www.w3.org/qt4cg/subtyping" file="Subtyping/compareTypes.xquery"/>
       <test>
          import module namespace sub="http://www.w3.org/qt4cg/subtyping";
          sub:isSubtype('document-node(a|b)', '(document-node(a)|document-node(b)|document-node(c))')
       </test>
       <result>
-         <assert-false/>
+         <assert-true/>
       </result>
    </test-case>
    


### PR DESCRIPTION
Per [3.3.2.5.2 Subtyping Nodes: Document Nodes](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-item-subtype-documents), rule 3, `A ⊆ B` is true if

> A is document-node(element(A1|A2|..., T)) (where T may be absent), and for each An, document-node(element(An, T)) ⊆ B 

Test case `subtyping-076` however expects this to return `false`:

```xquery
         import module namespace sub="http://www.w3.org/qt4cg/subtyping";
         sub:isSubtype('document-node(a|b)', '(document-node(a)|document-node(b)|document-node(c))')
```

This is changed to `true` here.