### PR TITLE
Update `fn:number` tests for 4.0 decimal-based comparison

### DIFF
--- a/fn/number.xml
+++ b/fn/number.xml
@@ -43,7 +43,30 @@
    <test-case name="fn-numberintg1args-2">
       <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:integer(mid range) </description>
       <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="change dependency to pre-4.0"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:number(xs:integer("830993497117024304")) eq 830993497117024304</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberintg1args-2a">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:integer(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="result false after PR2218 introduces decimal-based comparison"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:number(xs:integer("830993497117024304")) eq 830993497117024304</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberintg1args-2b">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:integer(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="extra xs:double construction needed after PR2218"/>
+      <test>fn:number(xs:integer("830993497117024304")) eq xs:double(830993497117024304)</test>
       <result>
          <assert-true/>
       </result>
@@ -70,7 +93,30 @@
    <test-case name="fn-numberdec1args-2">
       <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:decimal(mid range) </description>
       <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="change dependency to pre-4.0"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:number(xs:decimal("617375191608514839")) eq 617375191608514839</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberdec1args-2a">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:decimal(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="result false after PR2218 introduces decimal-based comparison"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:number(xs:decimal("617375191608514839")) eq 617375191608514839</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberdec1args-2b">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:decimal(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="extra xs:double construction needed after PR2218"/>
+      <test>fn:number(xs:decimal("617375191608514839")) eq xs:double(617375191608514839)</test>
       <result>
          <assert-true/>
       </result>
@@ -155,7 +201,30 @@
    <test-case name="fn-numberlng1args-2">
       <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:long(mid range) </description>
       <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="change dependency to pre-4.0"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:number(xs:long("-47175562203048468")) eq -47175562203048468</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberlng1args-2a">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:long(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="result false after PR2218 introduces decimal-based comparison"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:number(xs:long("-47175562203048468")) eq -47175562203048468</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberlng1args-2b">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:long(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="extra xs:double construction needed after PR2218"/>
+      <test>fn:number(xs:long("-47175562203048468")) eq xs:double(-47175562203048468)</test>
       <result>
          <assert-true/>
       </result>
@@ -209,7 +278,30 @@
    <test-case name="fn-numbernint1args-2">
       <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:negativeInteger(mid range) </description>
       <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="change dependency to pre-4.0"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:number(xs:negativeInteger("-297014075999096793")) eq -297014075999096793</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numbernint1args-2a">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:negativeInteger(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="result false after PR2218 introduces decimal-based comparison"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:number(xs:negativeInteger("-297014075999096793")) eq -297014075999096793</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numbernint1args-2b">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:negativeInteger(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="extra xs:double construction needed after PR2218"/>
+      <test>fn:number(xs:negativeInteger("-297014075999096793")) eq xs:double(-297014075999096793)</test>
       <result>
          <assert-true/>
       </result>
@@ -236,7 +328,30 @@
    <test-case name="fn-numberpint1args-2">
       <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:positiveInteger(mid range) </description>
       <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="change dependency to pre-4.0"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:number(xs:positiveInteger("52704602390610033")) eq 52704602390610033</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberpint1args-2a">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:positiveInteger(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="result false after PR2218 introduces decimal-based comparison"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:number(xs:positiveInteger("52704602390610033")) eq 52704602390610033</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numberpint1args-2b">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:positiveInteger(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="extra xs:double construction needed after PR2218"/>
+      <test>fn:number(xs:positiveInteger("52704602390610033")) eq xs:double(52704602390610033)</test>
       <result>
          <assert-true/>
       </result>
@@ -339,7 +454,30 @@
    <test-case name="fn-numbernni1args-2">
       <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:nonNegativeInteger(mid range) </description>
       <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="change dependency to pre-4.0"/>
+      <dependency type="spec" value="XP20 XP30 XP31 XQ10 XQ30 XQ31"/>
       <test>fn:number(xs:nonNegativeInteger("303884545991464527")) eq 303884545991464527</test>
+      <result>
+         <assert-true/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numbernni1args-2a">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:nonNegativeInteger(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="result false after PR2218 introduces decimal-based comparison"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>fn:number(xs:nonNegativeInteger("303884545991464527")) eq 303884545991464527</test>
+      <result>
+         <assert-false/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-numbernni1args-2b">
+      <description> Evaluates The "number" function with the arguments set as follows: $arg = xs:nonNegativeInteger(mid range) </description>
+      <created by="Carmelo Montanez" on="2004-12-13"/>
+      <modified by="Gunther Rademacher" on="2025-12-08" change="extra xs:double construction needed after PR2218"/>
+      <test>fn:number(xs:nonNegativeInteger("303884545991464527")) eq xs:double(303884545991464527)</test>
       <result>
          <assert-true/>
       </result>


### PR DESCRIPTION
[PR2218](https://github.com/qt4cg/qtspecs/pull/2218) changes mixed double-decimal comparisons to use decimal-based comparison. Large integers/decimals no longer compare equal to the doubles produced by `fn:number`. My understanding is that the result type of `fn:number` is **not** going to be changed to `xs:decimal`, so a few of its tests need to be adapted.

This PR

- restricts original tests to pre-4.0 specs
- adds 4.0 variants expecting false
- adds explicit `xs:double` versions to preserve the original intent