### PR TITLE
Fix `serialize-xhtml-150`

### DIFF
--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -2249,10 +2249,11 @@
     <test-case name="serialize-xhtml-150" covers-40="PR2259">
         <description>canonical serialization parameter: relative URIs not allowed as namespaces</description>
         <created by="Michael Kay" on="2021-04-09"/>
+        <modified by="Gunther Rademacher" on="2026-01-19" change="change my:ns to xmlns:my_ns"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
               let $params := map {"method": "xhtml", "canonical" : true()},
-                  $data := parse-xml("<html xmlns='http://www.w3.org/1999/xhtml' my:ns='local.ns'><body class='bclass' id='abc' bgcolor='black'/></html>")
+                  $data := parse-xml("<html xmlns='http://www.w3.org/1999/xhtml' xmlns:my_ns='local.ns'><body class='bclass' id='abc' bgcolor='black'/></html>")
               return serialize($data, $params)
         ]]></test>
         <result>


### PR DESCRIPTION
Test case `serialize-xhtml-150` deals with a namespace node with a relative URI, but it incorrectly declares an attribute instead of a namespace node.