### PR TITLE
Fix `serialize-json-207` and `serialize-json-208`

### DIFF
--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -3207,6 +3207,7 @@
     <test-case name="serialize-json-208" covers-40="PR2259">
         <description>canonical serialization parameter: example from RFC 8785</description>
         <created by="Michael Kay" on="2025-12-12"/>
+        <modified by="Gunther Rademacher" on="2026-01-19" change="replace map:items() by map:values()"/>
         <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
               let $params := map {"method": "json", "canonical" : true()},
@@ -3221,7 +3222,7 @@
                              }'),
                   $lex := serialize($data, $params),
                   $data2 := parse-json($lex)
-               return map:values($data2)
+               return map:items($data2)
                   (:          Expected argument order after sorting property strings:
                             
                               "Carriage Return"


### PR DESCRIPTION
Test cases `serialize-json-207` and `serialize-json-208` use function `map:values`, which is not defined. It should be `map:items`.