### PR TITLE
Add sandpit to catalog; fix duplicate test names in file.xml

### DIFF
--- a/catalog-schema.xsd
+++ b/catalog-schema.xsd
@@ -126,6 +126,7 @@
                         <xs:element ref="collection" />
                         <xs:element ref="static-base-uri" />
                         <xs:element ref="collation" />
+                        <xs:element ref="sandpit" />
                     </xs:choice>
                     <xs:attributeGroup ref="nameAttr" />
                     <xs:attributeGroup ref="refAttr" />
@@ -216,6 +217,32 @@
                     </xs:documentation>
                 </xs:annotation>
              </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="sandpit">
+        <xs:annotation>
+            <xs:documentation>
+                <div>
+                    <h3>sandpit</h3>
+                    <p>An element which defines a “sandpit”, a set of files that the tests can modify.</p>
+                    <p>The <code>path</code> attribute must point to an existing
+                    directory. The semantics of the <code>sandpit</code> are
+                    that the test driver copies that path to a temporary,
+                    writable location on disk. That location is made the current
+                    working directory before running the tests. After the tests
+                    have been run, the temporary sandpit should be deleted.</p>
+                </div> 
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="path" type="xs:string">
+               <xs:annotation>
+                    <xs:documentation>
+                        <p>Identifies the location of files to be copied to the sandpit.</p>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     

--- a/file/file.xml
+++ b/file/file.xml
@@ -2658,10 +2658,11 @@
       </all-of>
     </result>
   </test-case>
-  <test-case name="EXPath-file-writeBinary3-005">
+  <test-case name="EXPath-file-writeBinary3-006">
     <description>Use file:write-binary with three arguments, file already exists, offset just at end</description>
     <created by="John Lumley" on="2013-12-02"/>
     <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
+    <modified by="Norm Tovey-Walsh" on="2026-02-11" change="rename test to make the name unique"/>
     <environment ref="EXPath-file"/>
     <test>
         (if (file:exists("test.bin")) 
@@ -2838,23 +2839,6 @@
         file:create-dir("dir5"),
         file:children("dir5")
       </test>
-    <result>
-      <all-of>
-        <assert-empty/>
-        <assert>Q{http://expath.org/ns/file}exists("dir5")</assert>
-      </all-of>
-    </result>
-  </test-case>
-
-  <test-case name="EXPath-file-children-001">
-    <description>Return children of empty directory</description>
-    <created by="Christian Gruen" on="2015-01-29"/>
-    <environment ref="EXPath-file"/>
-    <test>
-      if (file:exists("dir5")) then file:delete("dir5", true()) else (),
-      file:create-dir("dir5"),
-      file:children("dir5")
-    </test>
     <result>
       <all-of>
         <assert-empty/>


### PR DESCRIPTION
Fix #320

At least one of those duplicates predates moving the test set into the qt4tests repo, so I imagine that the EXPath repo doesn’t have catalog tests.