### PR TITLE
Change the namespace prefix used for expath binary errors

### DIFF
--- a/bin/and.xml
+++ b/bin/and.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary-bitwise">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="empty.bin" select="xs:base64Binary('')"/>
     <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
     <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>

--- a/bin/not.xml
+++ b/bin/not.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary-bitwise">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="empty.bin" select="xs:base64Binary('')"/>
     <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
     <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>

--- a/bin/or.xml
+++ b/bin/or.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary-bitwise">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="empty.bin" select="xs:base64Binary('')"/>
     <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
     <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>

--- a/bin/pack-double.xml
+++ b/bin/pack-double.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/pack-float.xml
+++ b/bin/pack-float.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/pack-integer.xml
+++ b/bin/pack-integer.xml
@@ -8,7 +8,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/shift.xml
+++ b/bin/shift.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary-bitwise">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="empty.bin" select="xs:base64Binary('')"/>
     <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
     <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>

--- a/bin/unpack-double.xml
+++ b/bin/unpack-double.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/unpack-float.xml
+++ b/bin/unpack-float.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/unpack-integer.xml
+++ b/bin/unpack-integer.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/unpack-unsigned-integer.xml
+++ b/bin/unpack-unsigned-integer.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary.numeric">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="int.byte" select="5"/>
     <param name="int.short" select="256 * 1 + 5"/>
     <param name="int.3" select="65536 * 1 + 256 * 1 + 5"/>

--- a/bin/xor.xml
+++ b/bin/xor.xml
@@ -4,7 +4,7 @@
   <environment name="EXPath-binary-bitwise">
     <namespace prefix="bin" uri="http://expath.org/ns/binary"/>
     <namespace prefix="binJAVA" uri="java:org.expath.ns.binary.EXPathBinary"/>
-    <namespace prefix="err" uri="http://expath.org/ns/binary"/>
+    <namespace prefix="errbin" uri="http://expath.org/ns/binary"/>
     <param name="empty.bin" select="xs:base64Binary('')"/>
     <param name="a" select="xs:base64Binary(xs:hexBinary('F00F'))"/>
     <param name="b" select="xs:base64Binary(xs:hexBinary('0FF0'))"/>


### PR DESCRIPTION
Change the namespace prefix used for expath binary errors to avoid conflict with xqt-errors namespace.

The conflict for the "err" prefix causes an error when using the QT3toXSLT3converter.xsl tool. This is fixed by changing the prefix used for the EXPath binary error namespace in the environments used in various EXPath binary test sets.