### PR TITLE
Fix expected result of `subtyping-105`

### DIFF
--- a/misc/Subtyping.xml
+++ b/misc/Subtyping.xml
@@ -765,12 +765,13 @@
       <created by="Michael Kay" on="2024-08-21"/>
       <module uri="http://www.w3.org/qt4cg/subtyping" file="Subtyping/compareTypes.xquery"/>
       <modified by="Christian Gruen" on="2026-03-05" change="PR2413"/>
+      <modified by="Gunther Rademacher" on="2026-03-11" change="expect true regardless of order"/>
       <test>
          import module namespace sub="http://www.w3.org/qt4cg/subtyping";
          sub:isSubtype('record(a,b as xs:decimal)', 'record(b as xs:decimal, a)')
       </test>
       <result>
-         <assert-false/>
+         <assert-true/>
       </result>
    </test-case>
    


### PR DESCRIPTION
After extensible records had been dropped by qt4cg/qtspecs#2413. test case `subtyping-105` was changed recently from 

```xquery
sub:isSubtype('record(a,b as xs:decimal,*)', 'record(b as xs:decimal, a)')
```

to

```xquery
sub:isSubtype('record(a,b as xs:decimal)', 'record(b as xs:decimal, a)')
```

But the expected result of `false` was not changed to `true`. It is however affected by the change, because it was `false` because of the extensibility. The order of the fields is irrelevant.

The change here fixes the expected result accordingly.