### PR TITLE
Fix tests for `fn:build-dateTime` and `fn:dateTime-record` constructor

### DIFF
--- a/fn/build-dateTime.xml
+++ b/fn/build-dateTime.xml
@@ -20,7 +20,8 @@
 	<test-case name="fn-build-dateTime-dateTime-with-timezone-from-map">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:dateTime, with a timezone</description>
 		<created by="Michael Kay" on="2026-03-12"/>
-		<test>fn:build-dateTime({"year":1999, "month":5, "day":31, "hours":13, "minutes":20, "seconds":0, "timezone": xs:duration("-PT5H")))</test>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix query syntax"/>
+		<test>fn:build-dateTime({"year":1999, "month":5, "day":31, "hours":13, "minutes":20, "seconds":0, "timezone": xs:duration("-PT5H")})</test>
 		<result>
 			<all-of>
 				<assert-count>1</assert-count>
@@ -46,12 +47,13 @@
 	<test-case name="fn-build-dateTime-without-timezone-from-map">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:dateTime, without a timezone value.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime({"year":1999, "month":5, "day":31, "hours":13, "minutes":20, "seconds":0})</test>
 		<result>
 			<all-of>
 				<assert-count>1</assert-count>
 				<assert-type>xs:dateTime</assert-type>
-				<assert-string-value>2000-06-12T13:20:00</assert-string-value>
+				<assert-string-value>1999-05-31T13:20:00</assert-string-value>
 			</all-of>
 		</result>
 	</test-case>
@@ -163,7 +165,8 @@
 	<test-case name="fn-build-dateTime-time-high-precision">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time, where the seconds may need truncation.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
-		<test>fn:build-dateTime({"hours":23, "minutes":59, "seconds":59.999999999999999999999)</test>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix query syntax"/>
+		<test>fn:build-dateTime({"hours":23, "minutes":59, "seconds":59.999999999999999999999})</test>
 		<result>
 			<all-of>
 				<assert-count>1</assert-count>
@@ -174,14 +177,15 @@
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-negative zero">
-		<description>Evaluates fn:build-dateTime when the minutes and seconds are negative zero as doubles.</description>
+		<description>Evaluates fn:build-dateTime when the seconds are negative zero as double.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
-		<test>fn:build-dateTime({"hours":23, "minutes":-0.0e0, "seconds":-0.0e0)</test>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix query syntax, value, expected result"/>
+		<test>fn:build-dateTime({"hours":23, "minutes":0.0, "seconds":-0.0e0})</test>
 		<result>
 			<all-of>
 				<assert-count>1</assert-count>
 				<assert-type>xs:time</assert-type>
-				<assert>string($result) => starts-with("23:59:59.999")</assert>
+				<assert>string($result) eq "23:00:00"</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -345,7 +349,17 @@
 	<test-case name="fn-build-dateTime-gDay-coercion-from-xs:double">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay, without a timezone</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result (no coercion from double to integer)"/>
 		<test>fn:build-dateTime({"day": 3.1e1})</test>
+		<result>
+			<error code="XPTY0004"/>
+		</result>
+	</test-case>
+
+	<test-case name="fn-build-dateTime-gDay-coercion-from-xs:decimal">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay, without a timezone</description>
+		<created by="Gunther Rademacher" on="2026-03-18"/>
+		<test>fn:build-dateTime({"day": 31.0})</test>
 		<result>
 			<all-of>
 				<assert-count>1</assert-count>
@@ -358,18 +372,20 @@
 	<test-case name="fn-build-dateTime-dayTimeDuration">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:dayTimeDuration, which is not a valid input, even though it would be valid to create a dateTime-record that contains only timezone data.</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), (), (), (), xs:dayTimeDuration("PT6H")))</test>
 		<result>
-			<error code="XPTY0004" />
+			<error code="FODT0005"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-empty-record">
 		<description>Evaluates fn:build-dateTime when all the fields in the fn:dateTime-record are set to the fn:empty-sequence</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FODT0005"/>
 		</result>
 	</test-case>
 	
@@ -586,36 +602,40 @@
 	<test-case name="fn-build-dateTime-time-invalid-hours">
 		<description>Evaluates fn:build-dateTime when hours=24.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime({"hours":24, "minutes":0, "seconds":0})</test>
 		<result>
-			<error code="FODT0005" />
+			<error code="FODT0006" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-time-fractional-hours">
 		<description>Evaluates fn:build-dateTime when hours is fractional.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime({"hours":8.5, "minutes":0, "seconds":0})</test>
 		<result>
-			<error code="FOTY0004" />
+			<error code="XPTY0004"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-time-infinite-hours">
 		<description>Evaluates fn:build-dateTime when hours is infinity.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime({"hours":number("INF"), "minutes":0, "seconds":0})</test>
 		<result>
-			<error code="FOTY0004" />
+			<error code="XPTY0004"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-time-NaN">
 		<description>Evaluates fn:build-dateTime when the minutes and seconds are NaN as doubles.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:build-dateTime({"hours":23, "minutes":number('NaN'), "seconds":number('NaN')})</test>
 		<result>
-			<error code="FOTY0004"/>
+			<error code="XPTY0004"/>
 		</result>
 	</test-case>
 	
@@ -658,9 +678,10 @@
 	<test-case name="fn-build-dateTime-from-current-dateTime">
 		<description>Evaluates fn:build-dateTime applied to modified result of parts-of-dateTime</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix query (must not set timezone to empty sequence)"/>
 		<test>current-dateTime() 
 			   => parts-of-dateTime() 
-			   => map:put('timezone':())
+			   => map:remove('timezone')
 			   => fn:build-dateTime()
 			   => timezone-from-dateTime()
 		</test>

--- a/fn/dateTime-record.xml
+++ b/fn/dateTime-record.xml
@@ -7,6 +7,7 @@
 	<test-case name="fn-dateTime-record-empty-record">
 		<description>Creates a dateTime-record with the value of each field set to the empty sequence.</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record((), (), (), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -19,7 +20,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>			
+				<assert>map:size($result) eq 0</assert>			
 			</all-of>
 		</result>
 	</test-case>
@@ -47,6 +48,7 @@
 	<test-case name="fn-dateTime-record-dateTime-without-timezone">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:dateTime without a timezone value.</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record(xs:integer(2000), xs:integer(6), xs:integer(12), xs:integer(13), xs:integer(20), xs:decimal(0), ())</test>
 		<result>
 			<all-of>
@@ -59,7 +61,7 @@
 				<assert>$result?"minutes" eq 20</assert>
 				<assert>$result?"seconds" eq 0</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 6</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -68,6 +70,7 @@
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:date</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
 		<modified by="Christian Gruen" on="2026-03-13" change="duplicate test removed"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record(xs:integer(2026), xs:integer(2), xs:integer(21), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -80,7 +83,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 3</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -88,6 +91,7 @@
 	<test-case name="fn-dateTime-record-time">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:time</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record((), (), (), xs:integer(13), xs:integer(30), xs:decimal(04.2678), ())</test>
 		<result>
 			<all-of>
@@ -100,7 +104,7 @@
 				<assert>$result?"minutes" eq 30</assert>
 				<assert>$result?"seconds" eq 4.2678</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 3</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -108,6 +112,7 @@
 	<test-case name="fn-dateTime-record-gYear">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:gYear</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record(xs:integer(2007), (), (), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -120,7 +125,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 1</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -128,6 +133,7 @@
 	<test-case name="fn-dateTime-record-gYearMonth">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:gYearMonth</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record(xs:integer(2007), xs:integer(5), (), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -140,7 +146,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 2</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -148,6 +154,7 @@
 	<test-case name="fn-dateTime-record-gMonth">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:gMonth</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record((), xs:integer(10), (), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -160,7 +167,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 1</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -168,6 +175,7 @@
 	<test-case name="fn-dateTime-record-gMonthDay">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:gMonthDay</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record((), xs:integer(10), xs:integer(8), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -180,7 +188,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 2</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -188,6 +196,7 @@
 	<test-case name="fn-dateTime-record-gDay">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:gDay</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record((), (), xs:integer(8), (), (), (), ())</test>
 		<result>
 			<all-of>
@@ -200,7 +209,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>empty($result?"timezone")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 1</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -208,6 +217,7 @@
 	<test-case name="fn-dateTime-record-dayTimeDuration">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the arguments supplied are equivalent to an xs:dayTimeDuration for a timezone.</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record((), (), (), (), (), (), xs:dayTimeDuration("PT6H"))</test>
 		<result>
 			<all-of>
@@ -220,7 +230,7 @@
 				<assert>empty($result?"minutes")</assert>
 				<assert>empty($result?"seconds")</assert>
 				<assert>$result?"timezone" eq xs:dayTimeDuration("PT6H")</assert>
-				<assert>map:size($result) eq 7</assert>
+				<assert>map:size($result) eq 1</assert>
 			</all-of>
 		</result>
 	</test-case>
@@ -228,18 +238,20 @@
 	<test-case name="fn-dateTime-record-empty-sequence">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when the sole argument supplied is fn:empty-sequence</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record(())</test>
 		<result>
-			<assert>empty($result)</assert>
+			<assert>map:size($result) eq 0</assert>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-dateTime-record-zero-args">
 		<description>Evaluates the implicit constructor for fn:dateTime-record when no argument is supplied</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
+		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
 		<test>fn:dateTime-record()</test>
 		<result>
-			<error code="XPST0017" />
+			<assert>map:size($result) eq 0</assert>
 		</result>
 	</test-case>
 	


### PR DESCRIPTION
The changes here fix incorrect syntax and expectations in `fn:build-dateTime` and `fn:dateTime-record` tests:

- fixed malformed test queries (missing braces/parentheses).
- added a decimal coercion test for `xs:gDay`, as there is no `xs:double` to `xs:integer` coercion.
- fixed timezone removal test to use `map:remove`, as empty sequence for the timezone is not permitted in a valid `fn:dateTime-record`.
- corrected expected values and error codes:
    - `FODT0005` for invalid field combinations (e.g., timezone-only, empty record)
    - `FODT0006` for invalid values (e.g., hours = 24)
    - `XPTY0004` for type/coercion errors
- aligned `fn:dateTime-record` expectations:
   - `map:size()` reflects only present entries, as empty-valued fields are omitted
   - empty input returns an empty record (not `()` or error)
