### PR TITLE
Fixed invalid braced URI literal in `annotation-40-20`

### DIFF
--- a/prod/Annotation.xml
+++ b/prod/Annotation.xml
@@ -949,10 +949,11 @@
    <test-case name="annotation-40-20" covers-40="PR2061">
       <description>Literal QNames are allowed</description>
       <created by="Michael Kay" on="2025-06-28"/>
+      <modified by="Gunther Rademacher" on="2026-03-31" change="fixed invalid braced URI literal"/>
       <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
          declare namespace a = "http://www.example.org/annotation";
-         declare %a:target(#Q{"http://www.example.org/annotation"}practice) function local:foo() {
+         declare %a:target(#Q{http://www.example.org/annotation}practice) function local:foo() {
             "bar"
          };
          local:foo()


### PR DESCRIPTION
Test case `annotation-40-20` was using an invalid braced URI literal, the URI was quoted inside of the braces.