### PR TITLE
Add tests for literal backtick in element content

### DIFF
--- a/prod/StringConstructor.xml
+++ b/prod/StringConstructor.xml
@@ -468,6 +468,42 @@ bottles]``
       </result>
    </test-case>
    
+   <test-case name="string-constructor-035">
+      <description>Literal backtick in element content is treated as text, not as a string constructor or string template</description>
+      <created by="Joe Wicentowski" on="2026-04-07"/>
+      <test><![CDATA[<a>`</a>]]></test>
+      <result>
+         <all-of>
+            <assert-type>element(a)</assert-type>
+            <assert-string-value>`</assert-string-value>
+         </all-of>
+      </result>
+   </test-case>
+
+   <test-case name="string-constructor-036">
+      <description>Literal backtick following a child element in element content is treated as text, not a string constructor</description>
+      <created by="Joe Wicentowski" on="2026-04-07"/>
+      <test><![CDATA[<x><y/>`</x>]]></test>
+      <result>
+         <all-of>
+            <assert-type>element(x)</assert-type>
+            <assert-string-value>`</assert-string-value>
+         </all-of>
+      </result>
+   </test-case>
+
+   <test-case name="string-constructor-037">
+      <description>Literal backtick in element content following a string constructor is treated as text</description>
+      <created by="Joe Wicentowski" on="2026-04-07"/>
+      <test><![CDATA[let $s := ``[hello]`` return <a>{$s}`</a>]]></test>
+      <result>
+         <all-of>
+            <assert-type>element(a)</assert-type>
+            <assert-string-value>hello`</assert-string-value>
+         </all-of>
+      </result>
+   </test-case>
+
    <test-case name="string-constructor-901">
       <description>Unterminated string constructor </description>
       <created by="Michael Kay" on="2015-10-05"/>


### PR DESCRIPTION
## Summary

Adds three test cases (string-constructor-035 through 037) for the behavior of a literal backtick character appearing in XQuery element constructor content.

In XQuery 3.1, backtick is significant as the string constructor delimiter (``` ``[...]`` ```), but a bare backtick inside element content should be treated as an ordinary text character — not as the start of a string constructor. These tests confirm that behavior.

The tests pair with `string-constructor-027` ("Confusing enclosed expression in element constructor"), which tests `` ` `` in element content when followed by `{expr}`.

- **string-constructor-035**: backtick as sole element content: ```<a>`</a>```
- **string-constructor-036**: backtick following a child element in element content: ```<x><y/>`</x>```  
- **string-constructor-037**: backtick in element content after a string constructor result: ```let $s := ``[hello]`` return <a>{$s}`</a>```

## Background

This was discovered while investigating a parser bug in eXist-db's XQuery 4.0 parser implementation, where a stray backtick in element content was incorrectly tokenized as `STRING_TEMPLATE_START` instead of `ELEMENT_CONTENT`, causing a parse failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)