### PR TITLE
Rework HTML serialization results to allow meta charset=

### DIFF
--- a/ser/method-html.xml
+++ b/ser/method-html.xml
@@ -874,6 +874,7 @@ declare option output:version  "4.0";
     <modified by="O'Neil Delpratt" on="2013-05-30"
       change="added dependency inline with bug issue #21868"/>
     <modified by="Michael Kay" on="2013-06-14" change="relax the expected result pattern"/>
+    <modified by="Norm Tovey-Walsh" on="2026-04-13" change="allow meta charset="/>
     <dependency type="feature" value="serialization" satisfied="true"/>
     <dependency type="spec" value="XQ30 XQ31"/>
     <test><![CDATA[
@@ -890,7 +891,7 @@ declare option output:version  "5.0";
     <result>
       <all-of>
         <serialization-matches flags="i"
-          ><![CDATA[<!DOCTYPE\s+html\s*>\s*<html><head><meta +(?:(?:http-equiv=(['"])content-type\1 +content=(['"])text/html; *charset=UTF-8\2)|(?:content=(['"])text/html; *charset=UTF-8\3 +http-equiv=(['"])content-type\4)) *></head></html>]]></serialization-matches>
+          ><![CDATA[<!DOCTYPE\s+html\s*>\s*<html><head><meta +(?:(?:http-equiv=(['"])content-type\1 +content=(['"])text/html; *charset=UTF-8\2)|(?:content=(['"])text/html; *charset=UTF-8\3 +http-equiv=(['"])content-type\4)|charset=(['"])UTF-8\5) *></head></html>]]></serialization-matches>
         <serialization-matches><![CDATA[<!.......\s+(html|HTML)\s*>\s*<html><head><[^>]*></head></html>]]></serialization-matches>
       </all-of>
     </result>
@@ -931,6 +932,7 @@ declare option output:version  "5.0";
     <modified by="O'Neil Delpratt" on="2013-05-30"
       change="added dependency inline with bug issue #21868"/>
     <modified by="Michael Kay" on="2013-06-14" change="relax the expected result pattern"/>
+    <modified by="Norm Tovey-Walsh" on="2026-04-13" change="allow meta charset="/>
     <dependency type="feature" value="serialization" satisfied="true"/>
     <dependency type="spec" value="XQ30 XQ31"/>
     <test><![CDATA[
@@ -947,7 +949,7 @@ declare option output:version  "5.0";
     <result>
       <all-of>
         <serialization-matches flags="i"
-          ><![CDATA[<!DOCTYPE +html *>\s*<html><head><meta +(?:(?:http-equiv=(['"])content-type\1 +content=(['"])text/html; *charset=UTF-8\2)|(?:content=(['"])text/html; *charset=UTF-8\3 +http-equiv=(['"])content-type\4)) *></head></html>]]></serialization-matches>
+          ><![CDATA[<!DOCTYPE +html *>\s*<html><head><meta +(?:(?:http-equiv=(['"])content-type\1 +content=(['"])text/html; *charset=UTF-8\2)|(?:content=(['"])text/html; *charset=UTF-8\3 +http-equiv=(['"])content-type\4)|charset=(['"])UTF-8\5) *></head></html>]]></serialization-matches>
         <serialization-matches><![CDATA[<!....... +(html|HTML) *>\s*<html><head><[^>]*></head></html>]]></serialization-matches>
       </all-of>
     </result>

--- a/ser/method-xhtml.xml
+++ b/ser/method-xhtml.xml
@@ -576,6 +576,7 @@ declare option output:html-version  "4.0";
    <test-case name="Serialization-xhtml-36" >
       <description>Test media-type and include-content-type parameters for HTML 5.0, where input had a head element in no namespace</description>
       <created by="Michael Kay" on="2015-04-09"/>
+      <modified by="Norm Tovey-Walsh" on="2026-04-13" change="Relax the pattern to allow modern meta charset= form"/>
       <dependency type="spec" value="XQ30 XQ31"/>
       <test><![CDATA[
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -592,8 +593,7 @@ declare option output:html-version  "5.0";
         <all-of>
           <serialization-matches>&lt;meta</serialization-matches>
           <serialization-matches>&lt;!DOCTYPE\s+html\s*></serialization-matches>
-          <serialization-matches flags="i">http-equiv=['"]content-type['"]</serialization-matches>
-          <serialization-matches flags="i">content=['"]text/html; *charset=UTF-8['"]</serialization-matches>
+          <serialization-matches flags="i">charset=['"]UTF-8['"]</serialization-matches>
         </all-of>
       </result>
    </test-case>
@@ -601,6 +601,7 @@ declare option output:html-version  "5.0";
    <test-case name="Serialization-xhtml-36a" >
       <description>Test media-type and include-content-type parameters for HTML 5.0, where input had a head element in XHTML namespace</description>
       <created by="Michael Kay" on="2015-04-09"/>
+      <modified by="Norm Tovey-Walsh" on="2026-04-13" change="Relax the pattern to allow modern meta charset= form"/>
       <dependency type="spec" value="XQ30 XQ31"/>
       <test><![CDATA[
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -617,8 +618,7 @@ declare option output:html-version  "5.0";
         <all-of>
           <serialization-matches>&lt;meta</serialization-matches>
           <serialization-matches>&lt;!DOCTYPE\s+html\s*></serialization-matches>
-          <serialization-matches flags="i">http-equiv=['"]content-type['"]</serialization-matches>
-          <serialization-matches flags="i">content=['"]text/html; *charset=UTF-8['"]</serialization-matches>
+          <serialization-matches flags="i">charset=['"]UTF-8['"]</serialization-matches>
         </all-of>
       </result>
    </test-case>
@@ -653,6 +653,7 @@ declare option output:html-version  "5.0";
       <description>Test media-type and include-content-type parameters for HTML 5.0, 
         where input had a head element already containing a meta element, in no namespace</description>
       <created by="Michael Kay" on="2015-04-09"/>
+      <modified by="Norm Tovey-Walsh" on="2026-04-13" change="Relax the pattern to allow modern meta charset= form"/>
       <dependency type="spec" value="XQ30 XQ31"/>
       <test><![CDATA[
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -669,8 +670,7 @@ declare option output:html-version  "5.0";
         <all-of>
           <serialization-matches>&lt;meta</serialization-matches>
           <serialization-matches>&lt;!DOCTYPE\s+html\s*></serialization-matches>
-          <serialization-matches flags="i">http-equiv=['"]content-type['"]</serialization-matches>
-          <serialization-matches flags="i">content=['"]text/html; *charset=UTF-8['"]</serialization-matches>
+          <serialization-matches flags="i">charset=['"]UTF-8['"]</serialization-matches>
           <!-- there is at most one <meta> element and it has no separate end tag -->
           <not><serialization-matches>meta.*meta</serialization-matches></not>
         </all-of>
@@ -681,6 +681,7 @@ declare option output:html-version  "5.0";
       <description>Test media-type and include-content-type parameters for HTML 5.0, where input 
         had a head element already containing a meta element, in XHTML namespace</description>
       <created by="Michael Kay" on="2015-04-09"/>
+      <modified by="Norm Tovey-Walsh" on="2026-04-13" change="Relax the pattern to allow modern meta charset= form"/>
       <dependency type="spec" value="XQ30 XQ31"/>
       <test><![CDATA[
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
@@ -697,8 +698,7 @@ declare option output:html-version  "5.0";
         <all-of>
           <serialization-matches>&lt;meta</serialization-matches>
           <serialization-matches>&lt;!DOCTYPE\s+html\s*></serialization-matches>
-          <serialization-matches flags="i">http-equiv=['"]content-type['"]</serialization-matches>
-          <serialization-matches flags="i">content=['"]text/html; *charset=UTF-8['"]</serialization-matches>
+          <serialization-matches flags="i">charset=['"]UTF-8['"]</serialization-matches>
           <!-- there is at most one <meta> element and it has no separate end tag -->
           <not><serialization-matches>meta.*meta</serialization-matches></not>
         </all-of>


### PR DESCRIPTION
In HTML5, the form <meta charset="UTF-8"> has replaced some of the earlier "http-equiv" forms. This PR updates the regexes to allow (and require) the new forms.
