### PR TITLE
Change expected error of fn-doc-40-012

### DIFF
--- a/fn/doc.xml
+++ b/fn/doc.xml
@@ -685,8 +685,19 @@
       <description>Options on fn:doc - dtd validation requested, document is invalid</description>
       <created by="Michael Kay" on="2025-04-08"/>
       <modified by="Gunther Rademacher" on="2025-04-23" change="XML parser reports a DTD validation error, so added response code FODC0007"/>
+      <modified by="Gunther Rademacher" on="2026-04-28" change="new option 'trusted' defaults to false(), so expect error FODC0016"/>
       <dependency type="spec" value="XP40+ XQ40+"/>
       <test>exists(fn:doc("../docs/bib-invalid.xml", {'dtd-validation':true()})/*)</test>
+      <result>
+         <error code="FODC0016"/>
+      </result>
+   </test-case>
+
+   <test-case name="fn-doc-40-012a" covers-40="PR1910">
+      <description>Options on fn:doc - dtd validation requested, document is invalid</description>
+      <created by="Gunther Rademacher" on="2026-04-28"/>
+      <dependency type="spec" value="XP40+ XQ40+"/>
+      <test>exists(fn:doc("../docs/bib-invalid.xml", {'dtd-validation':true(), 'trusted':true()})/*)</test>
       <result>
          <any-of>
             <error code="FODC0002"/>


### PR DESCRIPTION
Test case `fn-doc-40-012` goes for a validation of document that is invalid by an external DTD. But `trusted` defaults to `false()`, so accessing the external DTD must be blocked.

Spawned off `fn-doc-40-012a` with `trusted` explicitly set to `true()`, and fixed the expected error of `fn-doc-40-012` to `FODC0016` ("External resources not available: call is untrusted.").