### PR TITLE
Updating tests associated with dateTime-record

### DIFF
--- a/fn/build-dateTime.xml
+++ b/fn/build-dateTime.xml
@@ -50,9 +50,10 @@
 	<test-case name="fn-build-dateTime-timezone-coercion-from-duration-invalid">
 		<description>Evaluates fn:build-dateTime when the timezone is an xs:duration greater than 840 minutes</description>
 		<created by="Sheila Thomson" on="2026-03-20"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FODT0003"/>
 		<test>fn:build-dateTime({"year":1999, "month":5, "day":31, "hours":13, "minutes":20, "seconds":0, "timezone": xs:duration("-P1DT5H")})</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FODT0003"/>
 		</result>
 	</test-case>
 	
@@ -114,7 +115,11 @@
 		<created by="Sheila Thomson" on="2026-04-02"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(-1), xs:integer(7), xs:integer(1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<all-of>
+				<assert-count>1</assert-count>
+				<assert-type>xs:date</assert-type>
+				<assert-string-value>-0001-07-01</assert-string-value>
+			</all-of>
 		</result>
 	</test-case>
 	
@@ -125,8 +130,8 @@
 		<result>
 			<all-of>
 				<assert-count>1</assert-count>
-				<assert-type>xs:gYearMonth</assert-type>
-				<assert-string-value>0000-07--</assert-string-value>
+				<assert-type>xs:date</assert-type>
+				<assert-string-value>0000-07-01</assert-string-value>
 			</all-of>
 		</result>
 	</test-case>
@@ -134,36 +139,40 @@
 	<test-case name="fn-build-dateTime-date-without-timezone-month-too-high">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the month value is greater than the max number of months in a year</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(13), xs:integer(1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-date-without-timezone-month-too-low">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the month value is less than 1</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(-1), xs:integer(1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 		<test-case name="fn-build-dateTime-date-without-timezone-day-too-high">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the day value is greater than the max number of days in any month</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(1), xs:integer(32), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-date-without-timezone-day-too-low">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the day value is less than 1</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(1), xs:integer(-1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
@@ -335,7 +344,11 @@
 		<created by="Sheila Thomson" on="2026-04-02"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(-1), (), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<all-of>
+				<assert-count>1</assert-count>
+				<assert-type>xs:gYear</assert-type>
+				<assert-string-value>-0001</assert-string-value>
+			</all-of>
 		</result>
 	</test-case>
 	
@@ -409,7 +422,11 @@
 		<created by="Sheila Thomson" on="2026-04-02"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(-1), xs:integer(7), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<all-of>
+				<assert-count>1</assert-count>
+				<assert-type>xs:gYearMonth</assert-type>
+				<assert-string-value>-0001-07</assert-string-value>
+			</all-of>
 		</result>
 	</test-case>
 	
@@ -421,7 +438,7 @@
 			<all-of>
 				<assert-count>1</assert-count>
 				<assert-type>xs:gYearMonth</assert-type>
-				<assert-string-value>0000-07--</assert-string-value>
+				<assert-string-value>0000-07</assert-string-value>
 			</all-of>
 		</result>
 	</test-case>
@@ -429,18 +446,20 @@
 	<test-case name="fn-build-dateTime-gYearMonth-without-timezone-month-too-high">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYearMonth (without a timezone) but the month value is greater than the max number of months in a year</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(13), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-gYearMonth-without-timezone-month-too-low">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYearMonth (without a timezone) but the month value is less than 1</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(-1), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
@@ -473,18 +492,20 @@
 	<test-case name="fn-build-dateTime-gMonth-without-timezone-month-too-high">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonth (without a timezone) but the month value is greater than the max number of months in a year</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(13), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-gMonth-without-timezone-month-too-low">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonth (without a timezone) but the month value is less than 1</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(-1), (), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
@@ -517,36 +538,40 @@
 	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-too-many-days">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the day value is greater than the max number of days for any month</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(7), xs:integer(40), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-too-few-days">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the day value is less than 1 day</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(7), xs:integer(-1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-month-too-high">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the month value is greater than the max number of months in a year</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(13), xs:integer(1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-month-too-low">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the month value is less than 1</description>
 		<created by="Sheila Thomson" on="2026-04-02"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(-1), xs:integer(1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
@@ -580,18 +605,20 @@
 	<test-case name="fn-build-dateTime-gDay-without-timezone-too-many-days">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay (without a timezone) greater than the max number of days for any month</description>
 		<created by="Sheila Thomson" on="2026-04-01"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), xs:integer(40), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-gDay-without-timezone-too-few-days">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay (without a timezone) where the value is less than 1 day</description>
 		<created by="Sheila Thomson" on="2026-04-01"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), xs:integer(-1), (), (), (), ()))</test>
 		<result>
-			<error code="FODT0006"/>
+			<error code="FORG0001"/>
 		</result>
 	</test-case>
 	
@@ -731,126 +758,140 @@
 	<test-case name="fn-build-dateTime-too-few-months">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with fewer than 0 months.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1970), xs:integer(-1), xs:integer(1), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-months">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with more than 12 months.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1970), xs:integer(13), xs:integer(1), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-few-days">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with fewer than 0 days.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1970), xs:integer(1), xs:integer(-1), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-days-usually-31">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with more than 31 days.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1970), xs:integer(1), xs:integer(32), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-days-usually-30">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with more than 30 days in a month that usually only has 30.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1970), xs:integer(11), xs:integer(31), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-days-feb-non-leap-year">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with more than 28 days, in February when it's not a leap year.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1913), xs:integer(2), xs:integer(29), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-days-feb-leap-year">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with more than 29 days, in February during a leap year.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1912), xs:integer(2), xs:integer(30), xs:integer(0), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-days-feb-leap-year-in-map">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date with more than 29 days, in February during a leap year.</description>
 		<created by="Michael Kay" on="2026-03-26"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime({"year": 1912, "month":2, "day":30})</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-few-hours">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with fewer than 0 hours.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), xs:integer(-1), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 		
 	<test-case name="fn-build-dateTime-too-many-hours">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with more than 24 hours.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), xs:integer(25), xs:integer(0), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-few-minutes">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with fewer than 0 minutes.</description>
 		<created by="Sheila Thomson" on="2026-03-03"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), xs:integer(0), xs:integer(-1), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-minutes">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with more than 59 minutes.</description>
 		<created by="Sheila Thomson" on="2026-03-03"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), xs:integer(0), xs:integer(61), xs:decimal(0.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-few-seconds">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with fewer than 0 seconds.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), xs:integer(0), xs:integer(0), xs:decimal(-1.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
 	<test-case name="fn-build-dateTime-too-many-seconds">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with 60 or more seconds.</description>
 		<created by="Sheila Thomson" on="2026-03-11"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime(fn:dateTime-record((), (), (), xs:integer(0), xs:integer(0), xs:decimal(60.0), ()))</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	
@@ -858,9 +899,10 @@
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with 60 or more seconds.</description>
 		<created by="Michael Kay" on="2026-03-26"/>
 		<modified by="Sheila Thomson" on="2026-04-01" change="added missing colon after hours, deleted extra closing round bracket" />
+		<modified by="Sheila Thomson" on="2026-04-29" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime({"hours": 12, "minutes":30, "seconds":60})</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	

--- a/fn/build-dateTime.xml
+++ b/fn/build-dateTime.xml
@@ -936,9 +936,10 @@
 		<description>Evaluates fn:build-dateTime when hours=24.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
 		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result"/>
+		<modified by="Sheila Thomson" on="2026-05-07" change="changed error code to FORG0001"/>
 		<test>fn:build-dateTime({"hours":24, "minutes":0, "seconds":0})</test>
 		<result>
-			<error code="FODT0006" />
+			<error code="FORG0001" />
 		</result>
 	</test-case>
 	

--- a/fn/build-dateTime.xml
+++ b/fn/build-dateTime.xml
@@ -289,7 +289,7 @@
 		<description>Evaluates fn:build-dateTime when the seconds are negative zero as double.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
 		<modified by="Gunther Rademacher" on="2026-03-18" change="fix query syntax, value, expected result"/>
-		<modified by="Sheila Thomson" on="2026-04-02" change="added missing hyphen to name" />
+		<modified by="Sheila Thomson" on="2026-04-02" change="changed name from fn-build-dateTime-negative-zero" />
 		<test>fn:build-dateTime({"hours":23, "minutes":0.0, "seconds":-0.0e0})</test>
 		<result>
 			<all-of>
@@ -626,7 +626,6 @@
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay, without a timezone</description>
 		<created by="Michael Kay" on="2026-03-12"/>
 		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result (no coercion from double to integer)"/>
-		<modified by="Sheila Thomson" on="2026-04-29" change="removed colon from test-case name"/>
 		<test>fn:build-dateTime({"day": 3.1e1})</test>
 		<result>
 			<error code="XPTY0004"/>

--- a/fn/build-dateTime.xml
+++ b/fn/build-dateTime.xml
@@ -109,6 +109,64 @@
 		</result>
 	</test-case>
 	
+	<test-case name="fn-build-dateTime-date-without-timezone-negative-year">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the year value is negative</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(-1), xs:integer(7), xs:integer(1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-date-without-timezone-year-zero">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the year value is zero</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(0), xs:integer(7), xs:integer(1), (), (), (), ()))</test>
+		<result>
+			<all-of>
+				<assert-count>1</assert-count>
+				<assert-type>xs:gYearMonth</assert-type>
+				<assert-string-value>0000-07--</assert-string-value>
+			</all-of>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-date-without-timezone-month-too-high">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the month value is greater than the max number of months in a year</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(13), xs:integer(1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-date-without-timezone-month-too-low">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the month value is less than 1</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(-1), xs:integer(1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+		<test-case name="fn-build-dateTime-date-without-timezone-day-too-high">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the day value is greater than the max number of days in any month</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(1), xs:integer(32), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-date-without-timezone-day-too-low">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date (without a timezone) but the day value is less than 1</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(1), xs:integer(-1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
 	<test-case name="fn-build-dateTime-date-without-timezone-from-nodes">
 		<description>Evaluates fn:build-dateTime supplying a map containing XML nodes</description>
 		<created by="Michael Kay" on="2026-03-26"/>
@@ -218,10 +276,11 @@
 		</result>
 	</test-case>
 	
-	<test-case name="fn-build-dateTime-negative-zero">
+	<test-case name="fn-build-dateTime-time-negative-zero">
 		<description>Evaluates fn:build-dateTime when the seconds are negative zero as double.</description>
 		<created by="Michael Kay" on="2026-03-12"/>
 		<modified by="Gunther Rademacher" on="2026-03-18" change="fix query syntax, value, expected result"/>
+		<modified by="Sheila Thomson" on="2026-04-02" change="added missing hyphen to name" />
 		<test>fn:build-dateTime({"hours":23, "minutes":0.0, "seconds":-0.0e0})</test>
 		<result>
 			<all-of>
@@ -267,6 +326,28 @@
 				<assert-count>1</assert-count>
 				<assert-type>xs:gYear</assert-type>
 				<assert-string-value>2007</assert-string-value>
+			</all-of>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gYear-without-timezone-negative-year">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYear (without a timezone) but the year value is negative</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(-1), (), (), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gYear-without-timezone-year-zero">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYear (without a timezone) but the year value is zero</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(0), (), (), (), (), (), ()))</test>
+		<result>
+			<all-of>
+				<assert-count>1</assert-count>
+				<assert-type>xs:gYear</assert-type>
+				<assert-string-value>0000</assert-string-value>
 			</all-of>
 		</result>
 	</test-case>
@@ -323,6 +404,46 @@
 		</result>
 	</test-case>
 	
+	<test-case name="fn-build-dateTime-gYearMonth-without-timezone-negative-year">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYearMonth (without a timezone) but the year value is negative</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(-1), xs:integer(7), (), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gYearMonth-without-timezone-year-zero">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYearMonth (without a timezone) but the year value is zero</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(0), xs:integer(7), (), (), (), (), ()))</test>
+		<result>
+			<all-of>
+				<assert-count>1</assert-count>
+				<assert-type>xs:gYearMonth</assert-type>
+				<assert-string-value>0000-07--</assert-string-value>
+			</all-of>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gYearMonth-without-timezone-month-too-high">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYearMonth (without a timezone) but the month value is greater than the max number of months in a year</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(13), (), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gYearMonth-without-timezone-month-too-low">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gYearMonth (without a timezone) but the month value is less than 1</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record(xs:integer(1), xs:integer(-1), (), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
 	<test-case name="fn-build-dateTime-gMonth-with-timezone">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonth, with a timezone</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -346,6 +467,24 @@
 				<assert-type>xs:gMonth</assert-type>
 				<assert-string-value>--10</assert-string-value>
 			</all-of>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gMonth-without-timezone-month-too-high">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonth (without a timezone) but the month value is greater than the max number of months in a year</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(13), (), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gMonth-without-timezone-month-too-low">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonth (without a timezone) but the month value is less than 1</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(-1), (), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
 		</result>
 	</test-case>
 	
@@ -375,6 +514,42 @@
 		</result>
 	</test-case>
 	
+	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-too-many-days">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the day value is greater than the max number of days for any month</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(7), xs:integer(40), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-too-few-days">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the day value is less than 1 day</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(7), xs:integer(-1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-month-too-high">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the month value is greater than the max number of months in a year</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(13), xs:integer(1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gMonthDay-without-timezone-month-too-low">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gMonthDay (without a timezone) but the month value is less than 1</description>
+		<created by="Sheila Thomson" on="2026-04-02"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), xs:integer(-1), xs:integer(1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
 	<test-case name="fn-build-dateTime-gDay-with-timezone">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay, with a timezone</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -401,10 +576,30 @@
 		</result>
 	</test-case>
 	
+
+	<test-case name="fn-build-dateTime-gDay-without-timezone-too-many-days">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay (without a timezone) greater than the max number of days for any month</description>
+		<created by="Sheila Thomson" on="2026-04-01"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), (), xs:integer(40), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
+	<test-case name="fn-build-dateTime-gDay-without-timezone-too-few-days">
+		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay (without a timezone) where the value is less than 1 day</description>
+		<created by="Sheila Thomson" on="2026-04-01"/>
+		<test>fn:build-dateTime(fn:dateTime-record((), (), xs:integer(-1), (), (), (), ()))</test>
+		<result>
+			<error code="FODT0006"/>
+		</result>
+	</test-case>
+	
 	<test-case name="fn-build-dateTime-gDay-coercion-from-xs-double">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:gDay, without a timezone</description>
 		<created by="Michael Kay" on="2026-03-12"/>
 		<modified by="Gunther Rademacher" on="2026-03-18" change="fix expected result (no coercion from double to integer)"/>
+		<modified by="Sheila Thomson" on="2026-04-29" change="removed colon from test-case name"/>
 		<test>fn:build-dateTime({"day": 3.1e1})</test>
 		<result>
 			<error code="XPTY0004"/>
@@ -509,6 +704,7 @@
 	<test-case name="fn-build-dateTime-year-zero-from-map">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:date during the year zero.</description>
 		<created by="Michael Kay" on="2026-03-26"/>
+		<modified by="Sheila Thomson" on="2026-04-01" change="Added missing timezone to expected result"/>
 		<test>fn:build-dateTime({"year":0, "month":1, "day":1, "timezone":xs:duration("PT0S")})</test>
 		<result>
 			<all-of>
@@ -661,6 +857,7 @@
 	<test-case name="fn-build-dateTime-too-many-seconds-in-map">
 		<description>Evaluates fn:build-dateTime when the fn:dateTime-record input represents an xs:time with 60 or more seconds.</description>
 		<created by="Michael Kay" on="2026-03-26"/>
+		<modified by="Sheila Thomson" on="2026-04-01" change="added missing colon after hours, deleted extra closing round bracket" />
 		<test>fn:build-dateTime({"hours": 12, "minutes":30, "seconds":60})</test>
 		<result>
 			<error code="FODT0006" />

--- a/fn/parts-of-dateTime.xml
+++ b/fn/parts-of-dateTime.xml
@@ -2,14 +2,17 @@
 <?xml-model href="../catalog-schema.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <test-set xmlns="http://www.w3.org/2010/09/qt-fots-catalog" name="fn-parts-of-dateTime">
 	<description>Tests for the parts-of-datetime() function</description>
-	<link type="spec" document="https://qt4cg.org/specifications/xpath-functions-40/Overview.html" idref="func-parts-of-dateTime"/>
+	<link type="spec" document="https://qt4cg.org/specifications/xpath-functions-40/Overview.html"
+		idref="func-parts-of-dateTime"/>
 
-   <dependency type="spec" value="XP40+ XQ40+"/>
+	<dependency type="spec" value="XP40+ XQ40+"/>
 
-	<test-case name="fn-parts-of-dateTime-dateTime-with-timezone">
-		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:dateTime, with a timezone</description>
+	<test-case name="fn-parts-of-dateTime-dateTimeStamp-with-timezone">
+		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:dateTimeStamp</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
-		<modified by="Michael Kay" on="2026-03-12" change="add check on specific type of result fields"/>
+		<modified by="Michael Kay" on="2026-03-12"
+			change="add check on specific type of result fields"/>
+		<modified by="Sheila Thomson" on="2026-03-26" change="tweaked name and description"/>
 		<test>fn:parts-of-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</test>
 		<result>
 			<all-of>
@@ -26,10 +29,11 @@
 			</all-of>
 		</result>
 	</test-case>
-	
-	<test-case name="fn-parts-of-dateTime-with-timezone-utc-z">
-		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:dateTime, with UTC timezone represented as 'Z'.</description>
+
+	<test-case name="fn-parts-of-dateTime-dateTimeStamp-with-timezone-utc-z">
+		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:dateTimeStamp, with UTC timezone represented as 'Z'.</description>
 		<created by="Sheila Thomson" on="2026-03-19"/>
+		<modified by="Sheila Thomson" on="2026-03-26" change="tweaked name and description"/>
 		<test>fn:parts-of-dateTime(xs:dateTime("2000-06-12T13:20:00Z"))</test>
 		<result>
 			<all-of>
@@ -46,11 +50,13 @@
 			</all-of>
 		</result>
 	</test-case>
-	
-	<test-case name="fn-parts-of-dateTime-without-timezone">
+
+	<test-case name="fn-parts-of-dateTime-dateTime-without-timezone">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:dateTime, without a timezone value.</description>
 		<created by="Sheila Thomson" on="2026-02-21"/>
-		<modified by="Sheila Thomson" on="2026-03-19" change="removed trailing 'Z' from input; expected size reduced to 6 and timezone now expected empty"/>
+		<modified by="Sheila Thomson" on="2026-03-19"
+			change="removed trailing 'Z' from input; expected size reduced to 6 and timezone now expected empty"/>
+		<modified by="Sheila Thomson" on="2026-03-26" change="tweaked name"/>
 		<test>fn:parts-of-dateTime(xs:dateTime("2000-06-12T13:20:00"))</test>
 		<result>
 			<all-of>
@@ -67,11 +73,12 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-date">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:date</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
-		<modified by="Sheila Thomson" on="2026-03-19" change="expected size reduced to 3 and timezone now expected empty"/>
+		<modified by="Sheila Thomson" on="2026-03-19"
+			change="expected size reduced to 3 and timezone now expected empty"/>
 		<test>fn:parts-of-dateTime(xs:date("2026-02-21"))</test>
 		<result>
 			<all-of>
@@ -88,11 +95,12 @@
 			</all-of>
 		</result>
 	</test-case>
-	
-	<test-case name="fn-parts-of-dateTime-time">
-		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:time</description>
+
+	<test-case name="fn-parts-of-dateTime-time-microsecond-precision">
+		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:time, with minimum required precision</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
 		<modified by="Sheila Thomson" on="2026-03-19" change="expected size reduced to 3"/>
+		<modified by="Sheila Thomson" on="2026-03-26" change="tweaked name and description"/>
 		<test>fn:parts-of-dateTime(xs:time("13:30:04.2678"))</test>
 		<result>
 			<all-of>
@@ -109,7 +117,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-time-midnight-as-24">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:time, and the hour is set to '24'. Value ranges not expected to be validated so record expected, not an error.</description>
 		<created by="Sheila Thomson" on="2026-03-20"/>
@@ -129,7 +137,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-dateTime-midnight-as-24">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:dateTime, and the hour is set to '24'. Value ranges not expected to be validated so record expected, not an error.</description>
 		<created by="Sheila Thomson" on="2026-03-20"/>
@@ -149,7 +157,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-gYear">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:gYear</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -170,7 +178,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-gYearMonth">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:gYearMonth</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -191,7 +199,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-gMonth">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:gMonth</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -212,7 +220,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-gMonthDay">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:gMonthDay</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -233,7 +241,7 @@
 			</all-of>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-gDay">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is an xs:gDay</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -254,19 +262,32 @@
 			</all-of>
 		</result>
 	</test-case>
-	
-	<test-case name="fn-parts-of-dateTime-round-trip">
-		<description>Test round tripping</description>
+
+
+	<test-case name="fn-parts-of-dateTime-round-trip-dateTimeStamp-microsecond-precision">
+		<description>Test round tripping using a dateTimeStamp with microsecond precision.</description>
+		<created by="Sheila Thomson" on="2026-03-26"/>
+		<test>xs:dateTime("1999-05-31T13:30:04.2678") => fn:parts-of-dateTime() => build-dateTime() => atomic-equal(xs:dateTime("1999-05-31T13:30:04.2678"))</test>
+		<result>
+			<assert-true/>
+		</result>
+	</test-case>
+
+
+	<test-case name="fn-parts-of-dateTime-round-trip-dateTimeStamp-nanosecond-precision">
+		<description>Test round tripping using a dateTimeStamp with nanosecond precision</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Sheila Thomson" on="2026-03-26" change="Renamed and extended description"/>
 		<test>current-dateTime() => fn:parts-of-dateTime() => build-dateTime() => atomic-equal(current-dateTime())</test>
 		<result>
 			<assert-true/>
 		</result>
 	</test-case>
-	
-	<test-case name="fn-parts-of-dateTime-round-trip-altered">
-		<description>Test round tripping and alteration</description>
+
+	<test-case name="fn-parts-of-dateTime-round-trip-dateTimeStamp-altered-nanosecond-precision">
+		<description>Test round tripping and alteration using a dateTimeStamp with nanosecond precision</description>
 		<created by="Michael Kay" on="2026-03-12"/>
+		<modified by="Sheila Thomson" on="2026-03-26" change="Renamed and extended description"/>
 		<test>current-dateTime() 
 			   => fn:parts-of-dateTime()
 			   => map:remove("timezone")
@@ -284,10 +305,10 @@
 		<created by="Sheila Thomson" on="2026-02-24"/>
 		<test>fn:parts-of-dateTime(xs:dayTimeDuration("-PT5H"))</test>
 		<result>
-			<error code="XPTY0004" />
+			<error code="XPTY0004"/>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-empty-sequence">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is fn:empty-sequence</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
@@ -296,32 +317,32 @@
 			<assert-empty/>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-zero-args">
 		<description>Evaluates fn:parts-of-dateTime when no argument is supplied</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
 		<test>fn:parts-of-dateTime()</test>
 		<result>
-			<error code="XPST0017" />
+			<error code="XPST0017"/>
 		</result>
 	</test-case>
-			
+
 	<test-case name="fn-parts-of-dateTime-multiple-args">
 		<description>Evaluates fn:parts-of-dateTime when more than one xs:date is supplied</description>
 		<created by="Sheila Thomson" on="2026-02-18"/>
 		<test>fn:parts-of-dateTime(xs:date("1941-10-08"), xs:time("13:30:04.2678"))</test>
 		<result>
-			<error code="XPST0017" />
+			<error code="XPST0017"/>
 		</result>
 	</test-case>
-	
+
 	<test-case name="fn-parts-of-dateTime-string">
 		<description>Evaluates fn:parts-of-dateTime when the sole argument supplied is a string, which is not one of the expected datatypes.</description>
 		<created by="Sheila Thomson" on="2026-02-24"/>
 		<test>fn:parts-of-dateTime("today")</test>
 		<result>
-			<error code="XPTY0004" />
+			<error code="XPTY0004"/>
 		</result>
 	</test-case>
-	
+
 </test-set>


### PR DESCRIPTION
Changes to tests for `fn:build-dateTime`:
* additional tests to check that component values fall within the permitted range
* updated error codes to match https://github.com/qt4cg/qtspecs/pull/2601

Changes to tests for `fn:parts-of-dateTime`:
* additional test for round-tripping dateTimeStamp with _microsecond_ precision
* standardised some test names
* fleshed out some descriptions