### PR TITLE
Expath file path to native

### DIFF
--- a/file/file.xml
+++ b/file/file.xml
@@ -2934,6 +2934,7 @@
     <created by="Michael Kay" on="2012-06-11"/>
     <modified by="John Lumley" on="2014-08-11" change="consistent EXPath naming"/>
     <modified by="Christian Gruen" on="2026-02-09" change="may yield an error"/>
+    <modified by="Sheila Thomson" on="2026-05-12" change="added not-found error as it is up to the implementation whether to return the invalid-path error instead."/>
     <environment ref="EXPath-file"/>
     <test>
          file:path-to-native("//test.txt")
@@ -2941,6 +2942,7 @@
     <result>
       <any-of>
         <error code="Q{http://expath.org/ns/file}invalid-path"/>
+        <error code="Q{http://expath.org/ns/file}not-found"/>
         <assert>ends-with($result, "test.txt")</assert>
         <assert>ends-with($result, "sandpit\test.txt")</assert>
       </any-of>


### PR DESCRIPTION
Extended `EXPath-file-pathToNative-002` in the `expath-file` test set so that `file:not-found` is also a valid outcome.  Previously the only accepted error was `file:invalid-path` but https://qt4cg.org/specifications/expath-file-40/Overview.html#file-paths says:

> It is [implementation-dependent](https://qt4cg.org/specifications/xpath-functions-40/#implementation-dependent) whether the error [[file:invalid-path](https://qt4cg.org/specifications/expath-file-40/Overview.html#ERRFILE40invalid-path)] is raised if a path is invalid, i.e., if it contains characters that are not allowed in a specific file system.

and https://qt4cg.org/specifications/expath-file-40/Overview.html#func-file-path-to-native says:

> [[file:not-found](https://qt4cg.org/specifications/expath-file-40/Overview.html#ERRFILE40not-found)] is raised if the specified path does not exist.