### PR TITLE
Replace outdated `FilterExprAM` syntax

### DIFF
--- a/fn/siblings.xml
+++ b/fn/siblings.xml
@@ -105,8 +105,9 @@
    <test-case name="fn-siblings-010">
       <description>Context value is multiple nodes</description>
       <created by="Michael Kay" on="2024-11-06"/>
+      <modified by="Gunther Rademacher" on="2026-05-19" change="replace outdated FilterExprAM syntax"/>
       <environment ref="compass"/>
-      <test>[(//north, //far-north)] ?[ exists(siblings()) ]</test>
+      <test>(//north, //far-north) => fn{siblings()}()</test>
       <result>
          <error code="XPTY0004"/>
       </result>


### PR DESCRIPTION
With qt4cg/qtspecs#2608, the array/map filter syntax was removed, but test case `fn-siblings-010` is still using it.

The change here replaces it by different syntax while keeping up the original test intent.