### PR TITLE
Prod DirectConstructor

### DIFF
--- a/prod/DirectConstructor.xml
+++ b/prod/DirectConstructor.xml
@@ -199,30 +199,42 @@
    <test-case name="Constr-comment-6">
       <description> comment constructor - single dash </description>
       <created by="Andreas Behm" on="2005-02-22"/>
+      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." />
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!----->]]></test>
       <result>
-         <error code="XPST0003"/>
+         <any-of>
+      		<error code="XPST0003"/>
+      		<error code="XQDY0072"/>
+      	</any-of>
       </result>
    </test-case>
 
    <test-case name="Constr-comment-7">
       <description> comment constructor - trailing dash </description>
       <created by="Andreas Behm" on="2005-02-22"/>
+      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." />
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!--comment--->]]></test>
       <result>
-         <error code="XPST0003"/>
+         <any-of>
+      		<error code="XPST0003"/>
+      		<error code="XQDY0072"/>
+      	</any-of>
       </result>
    </test-case>
 
    <test-case name="Constr-comment-8">
       <description> comment constructor - double dash </description>
       <created by="Andreas Behm" on="2005-02-22"/>
+      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." />
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!--com--ment-->]]></test>
       <result>
-         <error code="XPST0003"/>
+         <any-of>
+      		<error code="XPST0003"/>
+      		<error code="XQDY0072"/>
+      	</any-of>
       </result>
    </test-case>
 
@@ -289,10 +301,14 @@
    <test-case name="K2-DirectConOther-7">
       <description> Syntax error in comment. </description>
       <created by="Frans Englich" on="2007-11-26"/>
+      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." /> 
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!-- -- -->]]></test>
       <result>
-         <error code="XPST0003"/>
+         <any-of>
+      		<error code="XPST0003"/>
+      		<error code="XQDY0072"/>
+      	</any-of>
       </result>
    </test-case>
 


### PR DESCRIPTION
Updated 4 tests in DirectConstructor to allow `XQDY0072` as a valid outcome, per the latest version of the XPath and XQuery specs.

XPath 4.0 § 4.13.2.6 [Computed Comment Constructors](https://qt4cg.org/specifications/xquery-40/xpath-40.html#id-computed-comments) and XQuery 4.0 § 4.12.3.6 [Computed Comment Constructors](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-computed-comments):

> It is a [dynamic error](https://qt4cg.org/specifications/xquery-40/xpath-40.html#dt-dynamic-error) [[err:XQDY0072](https://qt4cg.org/specifications/xquery-40/xpath-40.html#ERRXQDY0072)] if the result of the [content expression](https://qt4cg.org/specifications/xquery-40/xpath-40.html#dt-content-expression) of a computed comment constructor contains two adjacent hyphens or ends with a hyphen.