### PR TITLE
Revert "Prod DirectConstructor"

### DIFF
--- a/prod/DirectConstructor.xml
+++ b/prod/DirectConstructor.xml
@@ -199,42 +199,30 @@
    <test-case name="Constr-comment-6">
       <description> comment constructor - single dash </description>
       <created by="Andreas Behm" on="2005-02-22"/>
-      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." />
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!----->]]></test>
       <result>
-         <any-of>
-      		<error code="XPST0003"/>
-      		<error code="XQDY0072"/>
-      	</any-of>
+         <error code="XPST0003"/>
       </result>
    </test-case>
 
    <test-case name="Constr-comment-7">
       <description> comment constructor - trailing dash </description>
       <created by="Andreas Behm" on="2005-02-22"/>
-      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." />
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!--comment--->]]></test>
       <result>
-         <any-of>
-      		<error code="XPST0003"/>
-      		<error code="XQDY0072"/>
-      	</any-of>
+         <error code="XPST0003"/>
       </result>
    </test-case>
 
    <test-case name="Constr-comment-8">
       <description> comment constructor - double dash </description>
       <created by="Andreas Behm" on="2005-02-22"/>
-      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." />
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!--com--ment-->]]></test>
       <result>
-         <any-of>
-      		<error code="XPST0003"/>
-      		<error code="XQDY0072"/>
-      	</any-of>
+         <error code="XPST0003"/>
       </result>
    </test-case>
 
@@ -301,14 +289,10 @@
    <test-case name="K2-DirectConOther-7">
       <description> Syntax error in comment. </description>
       <created by="Frans Englich" on="2007-11-26"/>
-      <modified by="Sheila Thomson" on="2026-05-20" change="Extended to include more specific error code XQDY0072 as a valid outcome." /> 
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<!-- -- -->]]></test>
       <result>
-         <any-of>
-      		<error code="XPST0003"/>
-      		<error code="XQDY0072"/>
-      	</any-of>
+         <error code="XPST0003"/>
       </result>
    </test-case>
 


### PR DESCRIPTION
Reverts qt4cg/qt4tests#378

I don't think this change was correct. XQDY0072 applies to computed comment constructors, but these tests are for direct comment constructors, where a doubled hyphen is a syntax error, unambiguously XPST0003..

(There's no grammar scrap for direct comment constructors in §4.12.2. I'll raise a spec issue against that).