### PR TITLE
Ignore the results directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+# Ephemeral artefacts
 *.log*
-/results/sandpit
+/results/
 
 # Local IDE artefacts
 *.iml
@@ -7,3 +8,4 @@
 *.xpr
 .project
 .classpath
+/bin/

--- a/results/sandpit/put-101.xml
+++ b/results/sandpit/put-101.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?><test it="2025-12-15Z"/>


### PR DESCRIPTION
Broadening the scope of the .gitignore rules to ignore `/results/`, not just it's child `/results/sandpit/`.  Also removing `/results/sandpit/put-101.xml`.