### PR TITLE
Fix `serialize-canonical` tests

### DIFF
--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -3993,6 +3993,7 @@
             namespace prefix, and attr2 precedes b:attr because the default namespace is not applied 
             to unqualified attributes (so the namespace URI for attr2 is empty).</description>
         <created by="Joel Kalvesmaki" on="2025-03-16"/>
+        <modified by="Gunther Rademacher" on="2026-06-08" change="fixed indentation in expected result to match input"/>
         <environment>        
             <source role="." file="serialize/serialize-canonical-3-src.xml">
                 <description>File to be serialized</description>
@@ -4003,18 +4004,18 @@
         <test>serialize(., map {'method' : 'xml', 'canonical' : xs:untypedAtomic('true') })</test>
         <result>
             <assert-string-value><![CDATA[<doc>
-   <e1></e1>
-   <e2></e2>
-   <e3 id="elem3" name="elem3"></e3>
-   <e4 id="elem4" name="elem4"></e4>
-   <e5 xmlns="http://example.org" xmlns:a="http://www.w3.org" xmlns:b="http://www.ietf.org" attr="I'm" attr2="all" b:attr="sorted" a:attr="out"></e5>
-   <e6 xmlns:a="http://www.w3.org">
-      <e7 xmlns="http://www.ietf.org">
-         <e8 xmlns="">
-            <e9 xmlns:a="http://www.ietf.org" attr="default"></e9>
-         </e8>
-      </e7>
-   </e6>
+    <e1></e1>
+    <e2></e2>
+    <e3 id="elem3" name="elem3"></e3>
+    <e4 id="elem4" name="elem4"></e4>
+    <e5 xmlns="http://example.org" xmlns:a="http://www.w3.org" xmlns:b="http://www.ietf.org" attr="I'm" attr2="all" b:attr="sorted" a:attr="out"></e5>
+    <e6 xmlns:a="http://www.w3.org">
+        <e7 xmlns="http://www.ietf.org">
+            <e8 xmlns="">
+                <e9 xmlns:a="http://www.ietf.org" attr="default"></e9>
+            </e8>
+        </e7>
+    </e6>
 </doc>]]></assert-string-value>
         </result>
     </test-case>
@@ -4043,6 +4044,7 @@
             
             Note: The expr attribute of the second compute element contains no line breaks.</description>
         <created by="Joel Kalvesmaki" on="2025-03-16"/>
+        <modified by="Gunther Rademacher" on="2026-06-08" change="fixed indentation in expected result to match input"/>
         <environment>        
             <source role="." file="serialize/serialize-canonical-4-src.xml">
                 <description>File to be serialized</description>
@@ -4053,14 +4055,14 @@
         <test>serialize(., map {'method' : 'xml', 'canonical' : xs:untypedAtomic('true') })</test>
         <result>
             <assert-string-value><![CDATA[<doc>
-   <text>First line&#xD;
+    <text>First line&#xD;
 Second line</text>
-   <value>2</value>
-   <compute>value&gt;"0" &amp;&amp; value&lt;"10" ?"valid":"error"</compute>
-   <compute expr="value>&quot;0&quot; &amp;&amp; value&lt;&quot;10&quot; ?&quot;valid&quot;:&quot;error&quot;">valid</compute>
-   <norm attr=" '    &#xD;&#xA;&#x9;   ' "></norm>
-   <normNames attr="A &#xD;&#xA;&#x9; B"></normNames>
-   <normId id="' &#xD;&#xA;&#x9; '"></normId>
+    <value>2</value>
+    <compute>value&gt;"0" &amp;&amp; value&lt;"10" ?"valid":"error"</compute>
+    <compute expr="value>&quot;0&quot; &amp;&amp; value&lt;&quot;10&quot; ?&quot;valid&quot;:&quot;error&quot;">valid</compute>
+    <norm attr=" '    &#xD;&#xA;&#x9;   ' "></norm>
+    <normNames attr="A &#xD;&#xA;&#x9; B"></normNames>
+    <normId id="' &#xD;&#xA;&#x9; '"></normId>
 </doc>]]></assert-string-value>
         </result>
     </test-case>
@@ -4077,6 +4079,7 @@ Second line</text>
             External parsed entity reference replacement (including whitespace outside elements and PIs)
             External unparsed entity reference</description>
         <created by="Joel Kalvesmaki" on="2025-03-16"/>
+        <modified by="Gunther Rademacher" on="2026-06-08" change="fixed indentation in expected result to match input"/>
         <environment>        
             <source role="." file="serialize/serialize-canonical-5-src.xml">
                 <description>File to be serialized</description>
@@ -4087,7 +4090,7 @@ Second line</text>
         <test>serialize(., map {'method' : 'xml', 'canonical' : xs:untypedAtomic('true') })</test>
         <result>
             <assert-string-value><![CDATA[<doc attrExtEnt="entExt">
-   Hello, world!
+    Hello, world!
 </doc>]]></assert-string-value>
         </result>
     </test-case>
@@ -4104,6 +4107,7 @@ Second line</text>
             octets whose hexadecimal values are C2 and A9, which is the UTF-8 encoding of the 
             UCS codepoint for the copyright sign (©).</description>
         <created by="Joel Kalvesmaki" on="2025-03-16"/>
+        <modified by="Gunther Rademacher" on="2026-06-08" change="replaced #xC2#xA9 by ©"/>
         <environment>        
             <source role="." file="serialize/serialize-canonical-6-src.xml">
                 <description>File to be serialized</description>
@@ -4113,35 +4117,10 @@ Second line</text>
         <dependency type="spec" value="XP40+ XQ40+"/>
         <test>serialize(., map {'method' : 'xml', 'canonical' : xs:untypedAtomic('true') })</test>
         <result>
-            <assert-string-value><![CDATA[<doc>#xC2#xA9</doc>]]></assert-string-value>
+            <assert-string-value><![CDATA[<doc>©</doc>]]></assert-string-value>
         </result>
     </test-case>
 
-    <test-case name="serialize-canonical-7" covers="fn-serialize">
-        <description>Simple test for canonical serialization of XML. This example is taken from 
-            https://www.w3.org/TR/2008/REC-xml-c14n11-20080502/ section 3.7.
-            
-            Demonstrates:
-            
-            Empty default namespace propagation from omitted parent element
-            Propagation of attributes in the xml namespace in document subsets
-            Persistence of omitted namespace declarations in descendants
-            
-            Note: The canonical form contains no line delimiters.</description>
-        <created by="Joel Kalvesmaki" on="2025-03-16"/>
-        <environment>        
-            <source role="." file="serialize/serialize-canonical-6-src.xml">
-                <description>File to be serialized</description>
-                <created by="Joel Kalvesmaki" on="2026-03-16"/>
-            </source>
-        </environment>
-        <dependency type="spec" value="XP40+ XQ40+"/>
-        <test>serialize(., map {'method' : 'xml', 'canonical' : xs:untypedAtomic('true') })</test>
-        <result>
-            <assert-string-value><![CDATA[<doc>#xC2#xA9</doc>]]></assert-string-value>
-        </result>
-    </test-case>
-    
     <test-case name="serialize-canonical-7" covers="fn-serialize">
         <description>Remove dot segments algorithm for xml:base attribute. In this test, I have
             collected everything from appendix A in https://www.w3.org/TR/2008/REC-xml-c14n11-20080502 and


### PR DESCRIPTION
- Several of the new `serialize-canonical` tests expect the result to be indented differently than the input file: input files use an indentation size of 4, but the result expects 3. The changes in this PR fix the indentation to match the input.
- Test case `serialize-canonical-6` expects the string `#xC2#xA9` where it should expect a literal copyright sign.
- Apart from its name and description, the first occurrence of `serialize-canonical-7` is a duplicate of `serialize-canonical-6`. So this test case is removed here.