### PR TITLE
Add XQuery-only dependencies to tests that aren't valid XPath 4.0

### DIFF
--- a/fn/matching-segments.xml
+++ b/fn/matching-segments.xml
@@ -278,6 +278,8 @@ it put its sooty foot."
    <test-case name="matching-segments-029">
       <description> Matching groups within repeated clause </description>
       <created by="Michael Kay" on="2026-06-08"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (direct constructor)"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[
          let $data :=
            <Root>

--- a/prod/CompAttrConstructor.xml
+++ b/prod/CompAttrConstructor.xml
@@ -75,6 +75,8 @@
    <test-case name="Constr-compattr-compname-1">
       <description> empty computed name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>element elem {attribute {()} {'text'}}</test>
       <result>
          <error code="XPTY0004"/>
@@ -84,6 +86,8 @@
    <test-case name="Constr-compattr-compname-2">
       <description> two strings as name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>element elem {attribute {'one', 'two'} {'text'}}</test>
       <result>
          <error code="XPTY0004"/>
@@ -93,6 +97,8 @@
    <test-case name="Constr-compattr-compname-3">
       <description> two untypedAtomic values as name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>element elem {attribute {xs:untypedAtomic('one'), xs:untypedAtomic('two')} {'text'}}</test>
       <result>
          <error code="XPTY0004"/>
@@ -102,6 +108,8 @@
    <test-case name="Constr-compattr-compname-4">
       <description> content of two nodes as name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <environment ref="DupNode"/>
       <test>element elem {attribute {//a} {'text'}}</test>
       <result>
@@ -112,6 +120,8 @@
    <test-case name="Constr-compattr-compname-5">
       <description> two numeric values as name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>element elem {attribute {1,2} {'text'}}</test>
       <result>
          <error code="XPTY0004"/>
@@ -121,6 +131,8 @@
    <test-case name="Constr-compattr-compname-6">
       <description> numeric value as name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>element elem {attribute {123} {'text'}}</test>
       <result>
          <error code="XPTY0004"/>
@@ -130,6 +142,8 @@
    <test-case name="Constr-compattr-compname-7">
       <description> dataTime value as name </description>
       <created by="Andreas Behm" on="2005-05-20"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>element elem {attribute {xs:dateTime("1999-05-31T13:20:00")} {'text'}}</test>
       <result>
          <error code="XPTY0004"/>
@@ -316,7 +330,8 @@
    <test-case name="Constr-compattr-compname-25" covers-40="PR2665">
       <description> Attribute name supplied as xs:anyURI </description>
       <created by="Michael Kay" on="2026-06-11"/>
-      <dependency type="spec" value="XP40+ XQ40+" />
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ40+"/>
       <test>element x { attribute { xs:anyURI('abc')} { 12 } }</test>
       <result>
          <assert-xml><![CDATA[<x abc="12"/>]]></assert-xml>
@@ -825,6 +840,8 @@
    <test-case name="K2-ComputeConAttr-39">
       <description> This query yields XPST0081 because the prefix 'aPrefix' is unbound. </description>
       <created by="Frans Englich" on="2007-11-26"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>attribute aPrefix:localName {"content"}</test>
       <result>
          <error code="XPST0081"/>
@@ -883,6 +900,8 @@
    <test-case name="K2-ComputeConAttr-45">
       <description> One cannot create namespace declarations with computed attribute constructors(#2). </description>
       <created by="Frans Englich" on="2007-11-26"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>attribute xmlns {"content"}</test>
       <result>
          <error code="XQDY0044"/>
@@ -912,6 +931,8 @@
    <test-case name="K2-ComputeConAttr-48">
       <description> Ensure xml:id is properly normalized, and not done at the serialization stage. </description>
       <created by="Frans Englich" on="2007-11-26"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>string(attribute xml:id {" ab c d "})</test>
       <result>
          <any-of>

--- a/prod/CompDocConstructor.xml
+++ b/prod/CompDocConstructor.xml
@@ -195,6 +195,8 @@
    <test-case name="Constr-docnode-constrmod-3">
       <description> strip decimal type </description>
       <created by="Andreas Behm" on="2005-05-26"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (declare construction)"/>
+      <dependency type="spec" value="XQ10+"/>
       <environment ref="atomic"/>
       <test>declare construction strip; (document {//*:decimal})/* cast as xs:integer</test>
       <result>
@@ -205,6 +207,8 @@
    <test-case name="Constr-docnode-constrmod-4">
       <description> preserve decimal type </description>
       <created by="Andreas Behm" on="2005-05-26"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (declare construction)"/>
+      <dependency type="spec" value="XQ10+"/>
       <environment ref="atomic"/>
       <test>declare construction preserve; (document {//*:decimal})/* cast as xs:integer</test>
       <result>

--- a/prod/CompNamespaceConstructor.xml
+++ b/prod/CompNamespaceConstructor.xml
@@ -379,6 +379,8 @@
    <test-case name="nscons-024">
       <description>nscons-024 - dynamic namespace constructor - no effect on the statically known namespaces</description>
       <created by="Till Westmann" on="2011-11-28"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ30+"/>
       <test><![CDATA[
         element {'e'}{ namespace z { "http://www.zorba-xquery.com/" }, element z:e {} }
       ]]></test>
@@ -390,6 +392,8 @@
    <test-case name="nscons-025">
       <description>nscons-025 - dynamic namespace constructor - no effect on the statically known namespaces</description>
       <created by="Till Westmann" on="2011-11-28"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ30+"/>
       <test><![CDATA[
         element e { attribute z:a {},  namespace z { "http://www.zorba-xquery.com/" } }
       ]]></test>
@@ -401,6 +405,8 @@
    <test-case name="nscons-026">
       <description>nscons-026 - dynamic namespace constructor - no effect on the statically known namespaces</description>
       <created by="Till Westmann" on="2011-11-28"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (direct constructor)"/>
+      <dependency type="spec" value="XQ30+"/>
       <test><![CDATA[
         <e>{ namespace z { "http://www.zorba-xquery.com/" }, element { xs:QName("z:e") } { } }</e>
       ]]></test>
@@ -443,6 +449,8 @@
    <test-case name="nscons-029">
       <description>nscons-029 - dynamic namespace constructor - serialization of namespace node</description>
       <created by="Till Westmann" on="2011-11-28"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ30+"/>
       <test><![CDATA[
         serialize( namespace z { "http://www.zorba-xquery.com/" } )
       ]]></test>
@@ -650,8 +658,10 @@
    <test-case name="nscons-040">
       <description>nscons-040 - dynamic namespace constructor - use during validation</description>      
       <created by="Till Westmann" on="2011-11-28"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (schema import, validate)"/>
       <environment ref="cnc-schema"/>
       <dependency type="feature" value="schemaImport"/>
+      <dependency type="spec" value="XQ30+"/>
       <test><![CDATA[
         import schema namespace cnc="http://www.w3.org/TestSchemas/cnc";
 
@@ -718,7 +728,8 @@
   <test-case name="nscons-043a" covers-40="PR2665">
     <description>nscons-043 - dynamic namespace constructor - prefix expression is not string/untypedAtomic</description>
     <created by="Michael Kay" on="2014-08-17"/>
-    <dependency type="spec" value="XP40+ XQ40+"/>
+    <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (direct constructor)"/>
+    <dependency type="spec" value="XQ40+"/>
     <test><![CDATA[
         let $pre := xs:anyURI('ns'),
             $uri := "http://www.zorba-xquery.com/"
@@ -733,6 +744,8 @@
    <test-case name="nscons-044">
       <description>nscons-044 - dynamic namespace constructor - prefix expression is not string/untypedAtomic</description>
       <created by="Michael Kay" on="2014-08-17"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (direct constructor)"/>
+      <dependency type="spec" value="XQ30+"/>
       <test><![CDATA[
         let $pre := xs:duration('P1D'),
             $uri := "http://www.zorba-xquery.com/"

--- a/prod/CompPIConstructor.xml
+++ b/prod/CompPIConstructor.xml
@@ -331,6 +331,8 @@
    <test-case name="Constr-comppi-namexml-1">
       <description> invalid PI target xml </description>
       <created by="Andreas Behm" on="2005-08-17"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>processing-instruction xml {'pi'}</test>
       <result>
          <error code="XQDY0064"/>
@@ -340,6 +342,8 @@
    <test-case name="Constr-comppi-namexml-2">
       <description> invalid PI target xml </description>
       <created by="Andreas Behm" on="2005-08-17"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>processing-instruction XmL {'pi'}</test>
       <result>
          <error code="XQDY0064"/>
@@ -367,6 +371,8 @@
    <test-case name="Constr-comppi-invalid-1">
       <description> invalid PI content </description>
       <created by="Andreas Behm" on="2005-08-17"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>processing-instruction pi {'?&gt;'}</test>
       <result>
          <error code="XQDY0026"/>
@@ -376,6 +382,8 @@
    <test-case name="Constr-comppi-invalid-2">
       <description> invalid PI content </description>
       <created by="Andreas Behm" on="2005-08-17"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>processing-instruction pi {'?&gt;text'}</test>
       <result>
          <error code="XQDY0026"/>
@@ -385,6 +393,8 @@
    <test-case name="Constr-comppi-invalid-3">
       <description> invalid PI content </description>
       <created by="Andreas Behm" on="2005-08-17"/>
+      <modified by="Gunther Rademacher" on="2026-07-09" change="XQuery only (bare name constructor)"/>
+      <dependency type="spec" value="XQ10+"/>
       <test>processing-instruction pi {'text?&gt;text'}</test>
       <result>
          <error code="XQDY0026"/>


### PR DESCRIPTION
The [RExification test](https://github.com/GuntherRademacher/rex-parser-generator/tree/main/docs/sample-grammars/XQuery-40) has detected a number of tests that fail to parse as XPath 4.0. XPath 4.0 does have computed constructors, so `prod/Comp*Constructor.xml` are marked `XP40+ XQ40+`, but some tests use forms that stay XQuery-only:

- bare-name constructors `element foo {}` (XPath needs `#foo` or `{expr}`)
- direct constructors `<e>…</e>`
- XQuery prolog: `declare construction`, `import schema`, `validate {}`

These now are provided with an XQuery-only `<dependency>` per test.