### PR TITLE
Fix XPath dependencies

### DIFF
--- a/file/file.xml
+++ b/file/file.xml
@@ -2710,7 +2710,9 @@
   <test-case name="EXPath-file-write3-003">
     <description>Use file:write with a serialization-parameters element, method text</description>
     <created by="Christian Gruen" on="2026-07-10"/>
+    <created by="Gunther Rademacher" on="2026-07-21" change="add XQ40+ dependency (no direct constructor in XPath)"/>
     <environment ref="EXPath-file"/>
+    <dependency type="spec" value="XQ40+"/>
     <test><![CDATA[
         file:write("wr.txt", <a>1</a>,
           <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">

--- a/prod/StepExpr.xml
+++ b/prod/StepExpr.xml
@@ -635,7 +635,8 @@
    <test-case name="Steps-lookup-12" covers-40="PR2747">
       <description>Axis step followed by a lookup.</description>
       <created by="Christian Gruen" on="2026-07-10"/>
-      <dependency type="spec" value="XP40+ XQ40+"/>
+      <created by="Gunther Rademacher" on="2026-07-21" change="remove XP40+ dependency (no direct constructor in XPath)"/>
+      <dependency type="spec" value="XQ40+"/>
       <test><![CDATA[<a><b/></a>/b?c]]></test>
       <result>
          <error code="XPTY0004"/>


### PR DESCRIPTION
Two new tests need to be excluded from XPath testing, because they have direct constructors which are unavailable in XPath.