### PR TITLE
Fix a number of wrong dependency elements in various tests

### DIFF
--- a/array/filter.xml
+++ b/array/filter.xml
@@ -157,7 +157,7 @@
         <created by="Michael Kay" on="2023-12-01"/>
         <environment ref="array"/>
         <dependency type="spec" value="XP30 XP31 XQ30 XQ31"/>
-        <test>array:filter(array{1 to 10}, fn($mem, $pos){$mem mod 2 = 0 and $pos mod 3 = 0})</test>
+        <test>array:filter(array{1 to 10}, function($mem, $pos){$mem mod 2 = 0 and $pos mod 3 = 0})</test>
         <result>
             <error code="XPTY0004"/>
         </result>

--- a/fn/filter.xml
+++ b/fn/filter.xml
@@ -452,7 +452,7 @@
       <description>Arity-2 callback not allowed in 3.1</description>
       <created by="Michael Kay" on="2023-11-30"/>
       <dependency type="spec" value="XP30 XP31 XQ30 XQ31"/>
-      <test>fn:filter(10 to 20, fn($it as xs:integer, $pos as xs:long) as xs:boolean {
+      <test>fn:filter(10 to 20, function($it as xs:integer, $pos as xs:long) as xs:boolean {
          $it gt 12 and $pos instance of xs:long} )</test>
       <result>
          <error code="XPTY0004"/>

--- a/fn/for-each-pair.xml
+++ b/fn/for-each-pair.xml
@@ -614,7 +614,7 @@
       <description>Arity-3 callback, not allowed in 3.1</description>
       <created by="Michael Kay" on="2023-12-01"/>
       <dependency type="spec" value="XP30 XP31 XQ30 XQ31"/>
-      <test>fn:for-each-pair( ("a", "b", "c", "x"), ("d", "e", "f"), fn($x,$y,$pos){[$pos,$x,$y]})</test>
+      <test>fn:for-each-pair( ("a", "b", "c", "x"), ("d", "e", "f"), function($x,$y,$pos){[$pos,$x,$y]})</test>
       <result>
          <error code="XPTY0004"/>
       </result>

--- a/fn/for-each.xml
+++ b/fn/for-each.xml
@@ -176,7 +176,7 @@
         <description>Arity-2 mapping function, not allowed in 3.1</description>
         <created by="Michael Kay" on="2023-11-30"/>
         <dependency type="spec" value="XP30 XP31 XQ30 XQ31"/>
-        <test>for-each(22 to 28, fn($it, $pos){$pos, $it})</test>
+        <test>for-each(22 to 28, function($it, $pos){$pos, $it})</test>
         <result>
             <error code="XPTY0004"/>
         </result>

--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -2126,7 +2126,7 @@
     <test-case name="serialize-xml-143" covers="fn-serialize">
         <description>omit-xml-declaration inconsistent with standalone</description>
         <created by="Michael Kay" on="2024-09-27"/>
-        <dependency type="spec" value="XP31+ XQ31+"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
             serialize(
                 parse-xml('<a/>'), 
@@ -2142,7 +2142,7 @@
     <test-case name="serialize-xml-144" covers="fn-serialize">
         <description>omit-xml-declaration inconsistent with standalone</description>
         <created by="Michael Kay" on="2024-09-27"/>
-        <dependency type="spec" value="XP31+ XQ31+"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
             serialize(
                 parse-xml('<a/>'), 
@@ -2158,7 +2158,7 @@
     <test-case name="serialize-xml-145" covers="fn-serialize">
         <description>omit-xml-declaration (which defaults to true) is inconsistent with standalone</description>
         <created by="Michael Kay" on="2024-09-27"/>
-        <dependency type="spec" value="XP31+ XQ31+"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
             serialize(
                 parse-xml('<a/>'), 
@@ -2173,7 +2173,7 @@
     <test-case name="serialize-xml-146" covers="fn-serialize">
         <description>omit-xml-declaration inconsistent with version/doctype-system</description>
         <created by="Michael Kay" on="2024-09-27"/>
-        <dependency type="spec" value="XP31+ XQ31+"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
             serialize(
                 parse-xml('<a/>'), 
@@ -2190,7 +2190,7 @@
     <test-case name="serialize-xml-147" covers="fn-serialize">
         <description>omit-xml-declaration (defaulting to true) inconsistent with version/doctype-system</description>
         <created by="Michael Kay" on="2024-09-27"/>
-        <dependency type="spec" value="XP31+ XQ31+"/>
+        <dependency type="spec" value="XP40+ XQ40+"/>
         <test><![CDATA[
             serialize(
                 parse-xml('<a/>'), 

--- a/prod/LetClause.xml
+++ b/prod/LetClause.xml
@@ -2787,6 +2787,7 @@
    <test-case name="let-arr-015a" covers-40="PR2055 PR2119">
       <description> Deconstruct array. </description>
       <created by="Christian Gruen" on="2025-07-31"/>
+      <dependency type="spec" value="XQ40+ XP40+"/>
       <test>let $[ $x as xs:integer, $y as xs:string, $z as xs:date ]:= [1,"two"] return ($x, $y, $z)</test>
       <result>
          <error code="FOAY0001"/>


### PR DESCRIPTION
Hey! I am using these tests to verify a XQuery Language Server. (https://github.com/DrRataplan/xq-lsp shameless plug) And I found some small issues with tests I could not get working while using an XQuery 3.1 parser.

Looking into this, the tests use XQuery 4 syntax, but do not specify XQuery 4 as a dependency.

Per case:
* fn:serialize -> some use the new `{'key':'value'}` syntax without the map keyword, but they do not specify the XQuery 4 spec as a dependency
* array:filter/fn:filter -> verify XQuery 3.1 processors do not allow the 2-arity callback, but use XQuery 4 syntax: `fn ($x) {$x}`
* LetClause doing a deconstruction but without a dependency element.

This PR fixes them. I did not add any `<modified/>` elements,. Should I?