### PR TITLE
Fix XQuery 4 syntax for some filter tests

### DIFF
--- a/fn/filter.xml
+++ b/fn/filter.xml
@@ -466,7 +466,7 @@
       <test>
          for $i in (1000, 2000)
          let $x := year-from-date(current-date()) idiv $i
-         return fn:filter(10 to 20, fn($it as xs:integer) as xs:boolean {$it - 10 gt $x} )</test>
+         return fn:filter(10 to 20, function($it as xs:integer) as xs:boolean {$it - 10 gt $x} )</test>
       <result>
          <assert-deep-eq>(13 to 20, 12 to 20)</assert-deep-eq>
       </result>
@@ -477,7 +477,7 @@
       <created by="Michael Kay" on="2026-07-21"/>
       <dependency type="spec" value="XP30+ XQ30+"/>
       <test>
-         fn:filter(1 to 1000, fn($it as xs:byte) as xs:boolean {$it lt 20} )</test>
+         fn:filter(1 to 1000, function($it as xs:byte) as xs:boolean {$it lt 20} )</test>
       <result>
          <error code="XPTY0004"/>
       </result>


### PR DESCRIPTION
They are marked as XQuery 3.0+ but used the new lambda syntax. I update the test set every week to verify conformance in xq-lsp (https://github.com/DrRataplan/xq-lsp). These show up as false positives (errors that should not be there).